### PR TITLE
Docs missing google() repo in settings.gradle

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/ReadMe.md
+++ b/libraries/tools/kotlin-symbol-processing-api/ReadMe.md
@@ -494,6 +494,7 @@ Here's a sample processor that you can check out: https://github.com/android/kot
       repositories {
               gradlePluginPortal()
               maven("https://dl.bintray.com/kotlin/kotlin-eap")
+              google()
       }
   }
   ```


### PR DESCRIPTION
Noticed that there is missed google repo for settings.gradle in docs.