### PR TITLE
Add origin for symbols to distinguish where symbols are from.

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSNode.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSNode.kt
@@ -9,5 +9,6 @@ package org.jetbrains.kotlin.ksp.symbol
  * Base class of every visitable program elements.
  */
 interface KSNode {
+    val origin: Origin
     fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R
 }

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/Origin.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/Origin.kt
@@ -5,14 +5,8 @@
 
 package org.jetbrains.kotlin.ksp.symbol
 
-/**
- * Visibility of the element
- */
-enum class Visibility {
-    PUBLIC,
-    PRIVATE,
-    PROTECTED,
-    INTERNAL,
-    LOCAL,
-    JAVA_PACKAGE,
+enum class Origin {
+    KOTLIN,
+    CLASS,
+    JAVA
 }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/VisibilityProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/VisibilityProcessor.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.getVisibility
+import org.jetbrains.kotlin.ksp.isVisibleFrom
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.KSClassDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSFunctionDeclaration
+
+class VisibilityProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun process(resolver: Resolver) {
+        val symbolA = resolver.getSymbolsWithAnnotation("TestA").single() as KSClassDeclaration
+        val symbolB = resolver.getSymbolsWithAnnotation("TestB").single() as KSClassDeclaration
+        val symbolD = resolver.getSymbolsWithAnnotation("TestD").single() as KSClassDeclaration
+        val allFunctions = (symbolA.superTypes.single().resolve()!!.declaration as KSClassDeclaration)
+            .declarations.filterIsInstance<KSFunctionDeclaration>()
+        allFunctions.map {
+            "${it.simpleName.asString()}: ${it.getVisibility()},visible in A, B, D: " +
+                    "${it.isVisibleFrom(symbolA)}, ${it.isVisibleFrom(symbolB)}, ${it.isVisibleFrom(symbolD)}"
+        }.map { results.add(it) }
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
@@ -14,7 +13,6 @@ import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSValueArgumentLiteImpl
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.resolve.constants.*
-import org.jetbrains.kotlin.resolve.descriptorUtil.classId
 
 class KSAnnotationDescriptorImpl(val descriptor: AnnotationDescriptor) : KSAnnotation {
     companion object {
@@ -22,6 +20,8 @@ class KSAnnotationDescriptorImpl(val descriptor: AnnotationDescriptor) : KSAnnot
 
         fun getCached(descriptor: AnnotationDescriptor) = cache.getOrPut(descriptor) { KSAnnotationDescriptorImpl(descriptor) }
     }
+
+    override val origin = Origin.CLASS
 
     override val annotationType: KSTypeReference by lazy {
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -29,6 +29,7 @@ class KSClassDeclarationDescriptorImpl(val descriptor: ClassDescriptor) : KSClas
         fun getCached(descriptor: ClassDescriptor) = cache.getOrPut(descriptor) { KSClassDeclarationDescriptorImpl(descriptor) }
     }
 
+    override val origin = Origin.CLASS
 
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
+import org.jetbrains.kotlin.ksp.symbol.Origin
 import org.jetbrains.kotlin.types.KotlinType
 
 class KSClassifierReferenceDescriptorImpl(val kotlinType: KotlinType) : KSClassifierReference {
@@ -15,6 +16,8 @@ class KSClassifierReferenceDescriptorImpl(val kotlinType: KotlinType) : KSClassi
 
         fun getCached(kotlinType: KotlinType) = cache.getOrPut(kotlinType) { KSClassifierReferenceDescriptorImpl(kotlinType) }
     }
+
+    override val origin = Origin.CLASS
 
     override val qualifier: KSClassifierReference?
         get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -26,8 +26,9 @@ class KSFunctionDeclarationDescriptorImpl(val descriptor: FunctionDescriptor) : 
         fun getCached(descriptor: FunctionDescriptor) = cache.getOrPut(descriptor) { KSFunctionDeclarationDescriptorImpl(descriptor) }
     }
 
-    override val containingFile: KSFile? = null
+    override val origin = Origin.CLASS
 
+    override val containingFile: KSFile? = null
 
     override val parentDeclaration: KSDeclaration? by lazy {
         val containingDescriptor = descriptor.parents.first()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -19,6 +19,8 @@ class KSPropertyDeclarationDescriptorImpl(val descriptor: VariableDescriptorWith
         fun getCached(descriptor: VariableDescriptorWithAccessors) = cache.getOrPut(descriptor) { KSPropertyDeclarationDescriptorImpl(descriptor) }
     }
 
+    override val origin = Origin.CLASS
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
@@ -17,6 +17,8 @@ class KSPropertyGetterDescriptorImpl(val descriptor: PropertyGetterDescriptor) :
         fun getCached(descriptor: PropertyGetterDescriptor) = cache.getOrPut(descriptor) { KSPropertyGetterDescriptorImpl(descriptor) }
     }
 
+    override val origin = Origin.CLASS
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
@@ -17,6 +17,8 @@ class KSPropertySetterDescriptorImpl(val descriptor: PropertySetterDescriptor) :
         fun getCached(descriptor: PropertySetterDescriptor) = cache.getOrPut(descriptor) { KSPropertySetterDescriptorImpl(descriptor) }
     }
 
+    override val origin = Origin.CLASS
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
@@ -5,10 +5,8 @@
 
 package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.fir.types.ProjectionKind
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
-import org.jetbrains.kotlin.types.StarProjectionImpl
 import org.jetbrains.kotlin.types.TypeProjection
 
 class KSTypeArgumentDescriptorImpl(val descriptor: TypeProjection) : KSTypeArgumentImpl() {
@@ -17,6 +15,8 @@ class KSTypeArgumentDescriptorImpl(val descriptor: TypeProjection) : KSTypeArgum
 
         fun getCached(descriptor: TypeProjection) = cache.getOrPut(descriptor) { KSTypeArgumentDescriptorImpl(descriptor) }
     }
+
+    override val origin = Origin.CLASS
 
     override val type: KSTypeReference by lazy {
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
@@ -21,6 +21,8 @@ class KSTypeParameterDescriptorImpl(val descriptor: TypeParameterDescriptor) : K
         fun getCached(descriptor: TypeParameterDescriptor) = cache.getOrPut(descriptor) { KSTypeParameterDescriptorImpl(descriptor) }
     }
 
+    override val origin = Origin.CLASS
+
     override val bounds: List<KSTypeReference> by lazy {
         descriptor.upperBounds.map { KSTypeReferenceDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
@@ -20,6 +20,8 @@ class KSTypeReferenceDescriptorImpl(val kotlinType: KotlinType) : KSTypeReferenc
         fun getCached(kotlinType: KotlinType) = cache.getOrPut(kotlinType) { KSTypeReferenceDescriptorImpl(kotlinType) }
     }
 
+    override val origin = Origin.CLASS
+
     override val element: KSReferenceElement by lazy {
         when {
             kotlinType.constructor.declarationDescriptor is ClassDescriptor -> KSClassifierReferenceDescriptorImpl.getCached(kotlinType)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSVariableParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSVariableParameterDescriptorImpl.kt
@@ -18,6 +18,8 @@ class KSVariableParameterDescriptorImpl(val descriptor: ValueParameterDescriptor
         fun getCached(descriptor: ValueParameterDescriptor) = cache.getOrPut(descriptor) { KSVariableParameterDescriptorImpl(descriptor) }
     }
 
+    override val origin = Origin.CLASS
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -17,6 +17,8 @@ class KSAnnotationJavaImpl(val psi: PsiAnnotation) : KSAnnotation {
         fun getCached(psi: PsiAnnotation) = cache.getOrPut(psi) { KSAnnotationJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val annotationType: KSTypeReference by lazy {
         KSTypeReferenceLiteJavaImpl.getCached(KSClassDeclarationJavaImpl.getCached(psi.nameReferenceElement!!.resolve() as PsiClass).asType(emptyList()))
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSCallableReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSCallableReferenceJavaImpl.kt
@@ -16,6 +16,8 @@ class KSCallableReferenceJavaImpl(val psi: PsiMethodReferenceType) : KSCallableR
         fun getCached(psi: PsiMethodReferenceType) = cache.getOrPut(psi) { KSCallableReferenceJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val functionParameters: List<KSVariableParameter>
         get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -30,6 +30,8 @@ class KSClassDeclarationJavaImpl(val psi: PsiClass) : KSClassDeclaration {
         fun getCached(psi: PsiClass) = cache.getOrPut(psi) { KSClassDeclarationJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 import com.intellij.psi.PsiClassType
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
+import org.jetbrains.kotlin.ksp.symbol.Origin
 
 class KSClassifierReferenceJavaImpl(val psi: PsiClassType) : KSClassifierReference {
     companion object {
@@ -15,6 +16,8 @@ class KSClassifierReferenceJavaImpl(val psi: PsiClassType) : KSClassifierReferen
 
         fun getCached(psi: PsiClassType) = cache.getOrPut(psi) { KSClassifierReferenceJavaImpl(psi) }
     }
+
+    override val origin = Origin.JAVA
 
     override val qualifier: KSClassifierReference?
         get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFileJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFileJavaImpl.kt
@@ -16,6 +16,8 @@ class KSFileJavaImpl(val psi: PsiJavaFile) : KSFile {
         fun getCached(psi: PsiJavaFile) = cache.getOrPut(psi) { KSFileJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val annotations: List<KSAnnotation> = emptyList()
 
     override val declarations: List<KSDeclaration> by lazy {
@@ -26,7 +28,7 @@ class KSFileJavaImpl(val psi: PsiJavaFile) : KSFile {
         psi.name
     }
 
-    override val packageName: KSName = KSNameImpl.getCached(psi.packageName)
+    override val packageName: KSName = KSNameImpl.getCached(if (psi.packageName == "") "<root>" else psi.packageName)
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitFile(this, data)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -20,6 +20,8 @@ class KSFunctionDeclarationJavaImpl(val psi: PsiMethod) : KSFunctionDeclaration 
         fun getCached(psi: PsiMethod) = cache.getOrPut(psi) { KSFunctionDeclarationJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -19,6 +19,8 @@ class KSPropertyDeclarationJavaImpl(val psi: PsiField) : KSPropertyDeclaration {
         fun getCached(psi: PsiField) = cache.getOrPut(psi) { KSPropertyDeclarationJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
@@ -17,6 +17,7 @@ class KSTypeArgumentJavaImpl(val psi: PsiType) : KSTypeArgumentImpl() {
         fun getCached(psi: PsiType) = cache.getOrPut(psi) { KSTypeArgumentJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
 
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
@@ -18,6 +18,8 @@ class KSTypeParameterJavaImpl(val psi: PsiTypeParameter) : KSTypeParameter {
         fun getCached(psi: PsiTypeParameter) = cache.getOrPut(psi) { KSTypeParameterJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -15,6 +15,8 @@ class KSTypeReferenceJavaImpl(val psi: PsiType) : KSTypeReference {
         fun getCached(psi: PsiType) = cache.getOrPut(psi) { KSTypeReferenceJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
@@ -14,7 +14,10 @@ class KSTypeReferenceLiteJavaImpl(val type: KSType) : KSTypeReference {
         fun getCached(type: KSType) = cache.getOrPut(type) { KSTypeReferenceLiteJavaImpl(type) }
     }
 
+    override val origin = Origin.JAVA
+
     override val element: KSReferenceElement? = null
+
     override val annotations: List<KSAnnotation> = emptyList()
 
     override val modifiers: Set<Modifier> = emptySet()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSValueArgumentJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSValueArgumentJavaImpl.kt
@@ -7,8 +7,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 
 import org.jetbrains.kotlin.ksp.symbol.KSAnnotation
 import org.jetbrains.kotlin.ksp.symbol.KSName
-import org.jetbrains.kotlin.ksp.symbol.KSValueArgument
-import org.jetbrains.kotlin.ksp.symbol.KSVisitor
+import org.jetbrains.kotlin.ksp.symbol.Origin
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSValueArgumentImpl
 
 class KSValueArgumentJavaImpl(override val name: KSName?, override val value: Any?) : KSValueArgumentImpl() {
@@ -17,6 +16,8 @@ class KSValueArgumentJavaImpl(override val name: KSName?, override val value: An
 
         fun getCached(name: KSName?, value: Any?) = cache.getOrPut(Pair(name, value)) { KSValueArgumentJavaImpl(name, value) }
     }
+
+    override val origin = Origin.JAVA
 
     override val isSpread: Boolean = false
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSVariableParameterJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSVariableParameterJavaImpl.kt
@@ -16,6 +16,7 @@ class KSVariableParameterJavaImpl(val psi: PsiParameter) : KSVariableParameter {
         fun getCached(psi: PsiParameter) = cache.getOrPut(psi) { KSVariableParameterJavaImpl(psi) }
     }
 
+    override val origin = Origin.JAVA
 
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -18,6 +18,8 @@ class KSAnnotationImpl(val ktAnnotationEntry: KtAnnotationEntry) : KSAnnotation 
         fun getCached(ktAnnotationEntry: KtAnnotationEntry) = cache.getOrPut(ktAnnotationEntry) { KSAnnotationImpl(ktAnnotationEntry) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val annotationType: KSTypeReference by lazy {
         KSTypeReferenceImpl.getCached(ktAnnotationEntry.typeReference!!)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSCallableReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSCallableReferenceImpl.kt
@@ -15,6 +15,8 @@ class KSCallableReferenceImpl(val ktFunctionType: KtFunctionType) : KSCallableRe
         fun getCached(ktFunctionType: KtFunctionType) = cache.getOrPut(ktFunctionType) { KSCallableReferenceImpl(ktFunctionType) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val typeArguments: List<KSTypeArgument> by lazy {
         ktFunctionType.typeArgumentsAsTypes.map { KSTypeArgumentLiteImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -25,6 +25,8 @@ class KSClassDeclarationImpl(val ktClassOrObject: KtClassOrObject) : KSClassDecl
         fun getCached(ktClassOrObject: KtClassOrObject) = cache.getOrPut(ktClassOrObject) { KSClassDeclarationImpl(ktClassOrObject) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val annotations: List<KSAnnotation> by lazy {
         ktClassOrObject.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
+import org.jetbrains.kotlin.ksp.symbol.Origin
 import org.jetbrains.kotlin.psi.*
 
 class KSClassifierReferenceImpl(val ktUserType: KtUserType) : KSClassifierReference {
@@ -16,6 +17,7 @@ class KSClassifierReferenceImpl(val ktUserType: KtUserType) : KSClassifierRefere
         fun getCached(ktUserType: KtUserType) = cache.getOrPut(ktUserType) { KSClassifierReferenceImpl(ktUserType) }
     }
 
+    override val origin = Origin.KOTLIN
 
     override val typeArguments: List<KSTypeArgument> by lazy {
         ktUserType.typeArguments.map { KSTypeArgumentKtImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
@@ -8,13 +8,18 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 import org.jetbrains.kotlin.ksp.symbol.KSDynamicReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
 import org.jetbrains.kotlin.ksp.symbol.KSVisitor
+import org.jetbrains.kotlin.ksp.symbol.Origin
 
 class KSDynamicReferenceImpl : KSDynamicReference {
     companion object {
         private val cache = KSDynamicReferenceImpl()
         fun getCached() = cache
     }
+
+    override val origin = Origin.KOTLIN
+
     override val typeArguments: List<KSTypeArgument> = listOf<KSTypeArgument>()
+
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitDynamicReference(this, data)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFileImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFileImpl.kt
@@ -16,6 +16,8 @@ class KSFileImpl(val file: KtFile) : KSFile {
         fun getCached(file: KtFile) = cache.getOrPut(file) { KSFileImpl(file) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val packageName: KSName by lazy {
         KSNameImpl.getCached(file.packageFqName.toString())
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -25,6 +25,8 @@ class KSFunctionDeclarationImpl(val ktFunction: KtFunction) : KSFunctionDeclarat
         fun getCached(ktFunction: KtFunction) = cache.getOrPut(ktFunction) { KSFunctionDeclarationImpl(ktFunction) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val annotations: List<KSAnnotation> by lazy {
         ktFunction.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -21,6 +21,8 @@ class KSPropertyDeclarationImpl(val ktProperty: KtProperty) : KSPropertyDeclarat
         fun getCached(ktProperty: KtProperty) = cache.getOrPut(ktProperty) { KSPropertyDeclarationImpl(ktProperty) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val annotations: List<KSAnnotation> by lazy {
         ktProperty.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -19,6 +19,8 @@ class KSPropertyDeclarationParameterImpl(val ktParameter: KtParameter) : KSPrope
         fun getCached(ktParameter: KtParameter) = cache.getOrPut(ktParameter) { KSPropertyDeclarationParameterImpl(ktParameter) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val extensionReceiver: KSTypeReference? = null
 
     override val getter: KSPropertyGetter? = null

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
@@ -19,6 +19,8 @@ class KSPropertyGetterImpl(val ktPropertyGetter: KtPropertyAccessor) : KSPropert
         fun getCached(ktPropertyGetter: KtPropertyAccessor) = cache.getOrPut(ktPropertyGetter) { KSPropertyGetterImpl(ktPropertyGetter) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val returnType: KSTypeReference? by lazy {
         val property = ktPropertyGetter.property
         if (property.typeReference != null) {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
@@ -16,6 +16,8 @@ class KSPropertySetterImpl(val ktPropertySetter: KtPropertyAccessor) : KSPropert
         fun getCached(ktPropertySetter: KtPropertyAccessor) = cache.getOrPut(ktPropertySetter) { KSPropertySetterImpl(ktPropertySetter) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val parameter: KSVariableParameter by lazy {
         ktPropertySetter.parameterList?.parameters?.singleOrNull()?.let { KSVariableParameterImpl.getCached(it) } ?: throw IllegalStateException()
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
@@ -17,6 +17,8 @@ class KSTypeAliasImpl(val ktTypeAlias: KtTypeAlias) : KSTypeAlias {
         fun getCached(ktTypeAlias: KtTypeAlias) = cache.getOrPut(ktTypeAlias) { KSTypeAliasImpl(ktTypeAlias) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val containingFile: KSFile by lazy {
         KSFileImpl.getCached(ktTypeAlias.containingKtFile)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentImpl.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.psi.KtProjectionKind
 import org.jetbrains.kotlin.psi.KtTypeProjection
 
-abstract class KSTypeArgumentImpl() : KSTypeArgument {
+abstract class KSTypeArgumentImpl : KSTypeArgument {
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitTypeArgument(this, data)
     }
@@ -32,6 +32,8 @@ class KSTypeArgumentKtImpl(val ktTypeArgument: KtTypeProjection) : KSTypeArgumen
 
         fun getCached(ktTypeArgument: KtTypeProjection) = cache.getOrPut(ktTypeArgument) { KSTypeArgumentKtImpl(ktTypeArgument) }
     }
+
+    override val origin = Origin.KOTLIN
 
     override val variance: Variance by lazy {
         when (ktTypeArgument.projectionKind) {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentLiteImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentLiteImpl.kt
@@ -12,9 +12,16 @@ class KSTypeArgumentLiteImpl(override val type: KSTypeReference, override val va
     companion object {
         private val cache = mutableMapOf<Pair<KSTypeReference, Variance>, KSTypeArgumentLiteImpl>()
 
-        fun getCached(type: KSTypeReference, variance: Variance) = cache.getOrPut(Pair(type, variance)) { KSTypeArgumentLiteImpl(type, variance) }
-        fun getCached(type: KtTypeReference) = cache.getOrPut(Pair(KSTypeReferenceImpl.getCached(type), Variance.INVARIANT)) { KSTypeArgumentLiteImpl(KSTypeReferenceImpl.getCached(type), Variance.INVARIANT) }
+        fun getCached(type: KSTypeReference, variance: Variance) = cache.getOrPut(Pair(type, variance)) {
+            KSTypeArgumentLiteImpl(type, variance)
+        }
+
+        fun getCached(type: KtTypeReference) = cache.getOrPut(Pair(KSTypeReferenceImpl.getCached(type), Variance.INVARIANT)) {
+            KSTypeArgumentLiteImpl(KSTypeReferenceImpl.getCached(type), Variance.INVARIANT)
+        }
     }
+
+    override val origin = Origin.KOTLIN
 
     override val annotations: List<KSAnnotation> = type.annotations
 }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -20,9 +20,11 @@ class KSTypeImpl(
     companion object {
         private val cache = mutableMapOf<KotlinType, KSTypeImpl>()
 
-        fun getCached(kotlinType: KotlinType,
-                      ksTypeArguments: List<KSTypeArgument>? = null,
-                      annotations: List<KSAnnotation> = listOf()) =
+        fun getCached(
+            kotlinType: KotlinType,
+            ksTypeArguments: List<KSTypeArgument>? = null,
+            annotations: List<KSAnnotation> = listOf()
+        ) =
             cache.getOrPut(kotlinType) { KSTypeImpl(kotlinType, ksTypeArguments, annotations) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
@@ -18,6 +18,8 @@ class KSTypeParameterImpl(val ktTypeParameter: KtTypeParameter, val owner: KtTyp
         fun getCached(ktTypeParameter: KtTypeParameter, owner: KtTypeParameterListOwner) = cache.getOrPut(Pair(ktTypeParameter, owner)) { KSTypeParameterImpl(ktTypeParameter, owner) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val name: KSName by lazy {
         KSNameImpl.getCached(ktTypeParameter.name!!)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceDeferredImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceDeferredImpl.kt
@@ -14,8 +14,12 @@ class KSTypeReferenceDeferredImpl(private val resolver: () -> KSType?) : KSTypeR
         fun getCached(resolver: () -> KSType?) = cache.getOrPut(resolver) { KSTypeReferenceDeferredImpl(resolver) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val annotations: List<KSAnnotation> = emptyList()
+
     override val element: KSReferenceElement? = null
+
     override val modifiers: Set<Modifier> = emptySet()
 
     private val resolved: KSType? by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
@@ -18,6 +18,8 @@ class KSTypeReferenceImpl(val ktTypeReference: KtTypeReference) : KSTypeReferenc
         fun getCached(ktTypeReference: KtTypeReference) = cache.getOrPut(ktTypeReference) { KSTypeReferenceImpl(ktTypeReference) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val annotations: List<KSAnnotation> by lazy {
         ktTypeReference.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSValueArgumentImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSValueArgumentImpl.kt
@@ -5,11 +5,7 @@
 
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
-import org.jetbrains.kotlin.ksp.symbol.KSAnnotation
-import org.jetbrains.kotlin.ksp.symbol.KSName
-import org.jetbrains.kotlin.ksp.symbol.KSValueArgument
-import org.jetbrains.kotlin.ksp.symbol.KSVisitor
-import org.jetbrains.kotlin.resolve.constants.ConstantValue
+import org.jetbrains.kotlin.ksp.symbol.*
 
 class KSValueArgumentLiteImpl(override val name: KSName, override val value: Any?) : KSValueArgumentImpl() {
     companion object {
@@ -18,12 +14,14 @@ class KSValueArgumentLiteImpl(override val name: KSName, override val value: Any
         fun getCached(name: KSName, value: Any?) = cache.getOrPut(Pair(name, value)) { KSValueArgumentLiteImpl(name, value) }
     }
 
-    override val annotations: List<KSAnnotation> = emptyList()
-    override val isSpread: Boolean = false
+    override val origin = Origin.KOTLIN
 
+    override val annotations: List<KSAnnotation> = emptyList()
+
+    override val isSpread: Boolean = false
 }
 
-abstract class KSValueArgumentImpl() : KSValueArgument {
+abstract class KSValueArgumentImpl : KSValueArgument {
     override fun hashCode(): Int {
         return name.hashCode() * 31 + value.hashCode()
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSVariableParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSVariableParameterImpl.kt
@@ -17,6 +17,8 @@ class KSVariableParameterImpl(val ktParameter: KtParameter) : KSVariableParamete
         fun getCached(ktParameter: KtParameter) = cache.getOrPut(ktParameter) { KSVariableParameterImpl(ktParameter) }
     }
 
+    override val origin = Origin.KOTLIN
+
     override val annotations: List<KSAnnotation> by lazy {
         ktParameter.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.java.KSPropertyDeclarationJavaImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.java.KSTypeArgumentJavaImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.*
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.types.KotlinType
@@ -116,6 +117,9 @@ fun MemberDescriptor.toKSModifiers(): Set<Modifier> {
         Visibilities.PROTECTED -> modifiers.add(Modifier.PROTECTED)
         Visibilities.PRIVATE -> modifiers.add(Modifier.PRIVATE)
         Visibilities.INTERNAL -> modifiers.add(Modifier.INTERNAL)
+        // Since there is no modifier for package-private, use No modifier to tell if a symbol from binary is package private.
+        JavaVisibilities.PACKAGE_VISIBILITY -> Unit
+        else -> throw IllegalStateException("unhandled visibility: ${this.visibility}")
     }
     return modifiers
 }

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -82,4 +82,9 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
     public void testVarianceTypeCheck() throws Exception {
         runTest("plugins/ksp/testData/api/varianceTypeCheck.kt");
     }
+
+    @TestMetadata("visibilities.kt")
+    public void testVisibilities() throws Exception {
+        runTest("plugins/ksp/testData/api/visibilities.kt");
+    }
 }

--- a/plugins/ksp/testData/api/visibilities.kt
+++ b/plugins/ksp/testData/api/visibilities.kt
@@ -1,0 +1,47 @@
+// TEST PROCESSOR: VisibilityProcessor
+// EXPECTED:
+// publicFun: PUBLIC,visible in A, B, D: true, true, true
+// packageFun: JAVA_PACKAGE,visible in A, B, D: true, false, true
+// privateFun: PRIVATE,visible in A, B, D: false, false, false
+// protectedFun: PROTECTED,visible in A, B, D: true, false, false
+// END
+
+// FILE: a.kt
+annotation class TestA
+annotation class TestB
+annotation class TestD
+
+@TestA
+class A : C() {
+}
+
+@TestD
+class D {}
+
+
+// FILE: C.java
+class C {
+    public int publicFun() {
+        return 1;
+    }
+
+    int packageFun() {
+        return 1;
+    }
+
+    private int privateFun() {
+        return 1;
+    }
+
+    protected int protectedFun() {
+        return 1;
+    }
+}
+
+// FILE: b.kt
+package somePackage
+
+import TestB
+
+@TestB
+class B


### PR DESCRIPTION
* Add origin for symbols to distinguish where symbols are from.
* Fix visibility checking for Java symbols and kotlin protected members with new origins.

Also reformatted some files.