### PR TITLE
Support building against official kotlinc releases

### DIFF
--- a/libraries/tools/kotlin-ksp-gradle/build.gradle
+++ b/libraries/tools/kotlin-ksp-gradle/build.gradle
@@ -9,19 +9,26 @@ pill {
 }
 
 dependencies {
-    compile project(':kotlin-gradle-plugin-api')
-    compile project(':kotlin-gradle-plugin-model')
+    if (hasProperty("kspBaseVersion")) {
+        String kspBaseVersion = properties["kspBaseVersion"] as String
+        compile "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kspBaseVersion"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kspBaseVersion"
+    } else {
+        compile project(':kotlin-gradle-plugin-api')
+        compile project(':kotlin-gradle-plugin-model')
 
-    compile kotlinStdlib()
-    compileOnly project(path: ':kotlin-compiler-embeddable', configuration: 'runtimeJar')
-    compileOnly project(':kotlin-symbol-processing')
+        compile kotlinStdlib()
+        compileOnly project(path: ':kotlin-compiler-embeddable', configuration: 'runtimeJar')
+    }
 
     compileOnly gradleApi()
 
     testCompile gradleApi()
     testCompile "junit:junit:4.12"
+}
 
-    embedded(project(":kotlin-symbol-processing")) { transitive = false }
+repositories {
+    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
 }
 
 tasks.withType(project.compileKotlin.class) {

--- a/libraries/tools/kotlin-ksp-gradle/src/main/kotlin/org/jetbrains/kotlin/ksp/gradle/KspSubplugin.kt
+++ b/libraries/tools/kotlin-ksp-gradle/src/main/kotlin/org/jetbrains/kotlin/ksp/gradle/KspSubplugin.kt
@@ -98,5 +98,5 @@ class KspKotlinGradleSubplugin : KotlinGradleSubplugin<AbstractCompile> {
 
     override fun getCompilerPluginId() = "org.jetbrains.kotlin.ksp"
     override fun getPluginArtifact(): SubpluginArtifact =
-        SubpluginArtifact(groupId = "org.jetbrains.kotlin", artifactId = KSP_ARTIFACT_NAME)
+        SubpluginArtifact(groupId = "org.jetbrains.kotlin", artifactId = KSP_ARTIFACT_NAME, version = javaClass.`package`.implementationVersion)
 }

--- a/libraries/tools/kotlin-ksp/build.gradle.kts
+++ b/libraries/tools/kotlin-ksp/build.gradle.kts
@@ -10,11 +10,21 @@ plugins {
 val packedJars by configurations.creating
 
 dependencies {
-    compile(kotlinStdlib())
     packedJars(project(":kotlin-symbol-processing")) { isTransitive = false }
     packedJars(project(":kotlin-symbol-processing-api")) { isTransitive = false }
     packedJars(project(":kotlin-ksp-gradle")) { isTransitive = false }
-    runtime(projectRuntimeJar(":kotlin-compiler-embeddable"))
+    if (hasProperty("kspBaseVersion")) {
+        val kspBaseVersion = properties["kspBaseVersion"] as String
+        implementation(kotlin("stdlib", kspBaseVersion))
+        runtime(kotlin("compiler-embeddable", kspBaseVersion))
+    } else {
+        compile(kotlinStdlib())
+        runtime(projectRuntimeJar(":kotlin-compiler-embeddable"))
+    }
+}
+
+repositories {
+    maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 projectTest(parallel = true) {

--- a/libraries/tools/kotlin-symbol-processing-api/build.gradle.kts
+++ b/libraries/tools/kotlin-symbol-processing-api/build.gradle.kts
@@ -38,8 +38,16 @@ sourceSets {
 }
 
 dependencies {
-    implementation(kotlinStdlib())
-    compileOnly(kotlinBuiltins())
+    if (hasProperty("kspBaseVersion")) {
+        val kspBaseVersion = properties["kspBaseVersion"] as String
+        implementation(kotlin("stdlib", kspBaseVersion))
+    } else {
+        implementation(kotlinStdlib())
+    }
+}
+
+repositories {
+    maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 publish()

--- a/plugins/ksp/build.gradle.kts
+++ b/plugins/ksp/build.gradle.kts
@@ -16,17 +16,28 @@ dependencies {
         testRuntime(intellijPluginDep("java"))
     }
 
-    compile(project(":compiler:util"))
-    compile(project(":compiler:cli"))
-    compile(project(":compiler:backend"))
-    compile(project(":compiler:frontend"))
-    compile(project(":compiler:frontend.java"))
-    compile(project(":compiler:plugin-api"))
-    compile(project(":kotlin-symbol-processing-api"))
     compileOnly(intellijCoreDep()) { includeJars("intellij-core") }
 
-    testCompile(projectTests(":compiler:tests-common"))
-    testCompile(commonDep("junit:junit"))
+    if (hasProperty("kspBaseVersion")) {
+        val kspBaseVersion = properties["kspBaseVersion"] as String
+        compile(kotlin("compiler", kspBaseVersion))
+        compile(project(":kotlin-symbol-processing-api"))
+    } else {
+        compile(project(":compiler:util"))
+        compile(project(":compiler:cli"))
+        compile(project(":compiler:backend"))
+        compile(project(":compiler:frontend"))
+        compile(project(":compiler:frontend.java"))
+        compile(project(":compiler:plugin-api"))
+        compile(project(":kotlin-symbol-processing-api"))
+
+        testCompile(projectTests(":compiler:tests-common"))
+        testCompile(commonDep("junit:junit"))
+    }
+}
+
+repositories {
+    maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 sourceSets {


### PR DESCRIPTION
To build `1.4-M1-dev-experimental-20200611` against `1.4-M1`, for example:
```
./gradlew kotlin-ksp:install kotlin-symbol-processing-api:install \
-PkspBaseVersion="1.4-M1" \
-Pbuild.number="1.4-M1-dev-experimental-20200611"
```