### PR TITLE
support for Java functions override 

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
@@ -159,7 +159,8 @@ fun KSDeclaration.isVisibleFrom(other: KSDeclaration): Boolean {
         this.isPrivate() -> this.isVisibleInPrivate(other)
         this.isPublic() -> true
         this.isInternal() && other.containingFile != null && this.containingFile != null -> true
-        this.isJavaPackagePrivate() -> this.isSamePackage(other)
+        // Non-private symbols in Java are always visible in same package.
+        this.origin == Origin.JAVA -> this.isSamePackage(other)
         this.isProtected() -> this.isVisibleInPrivate(other) || other.closestClassDeclaration()?.let {
             this.closestClassDeclaration()!!.asStarProjectedType().isAssignableFrom(it.asStarProjectedType())
         } ?: false

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/CheckOverrideProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/CheckOverrideProcessor.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.getDeclaredFunctions
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.KSClassDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSFunctionDeclaration
+
+class CheckOverrideProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun process(resolver: Resolver) {
+        val javaList = resolver.getClassDeclarationByName(resolver.getKSNameFromString("JavaList")) as KSClassDeclaration
+        val kotlinList = resolver.getClassDeclarationByName(resolver.getKSNameFromString("KotlinList")) as KSClassDeclaration
+        val getFunKt = resolver.getSymbolsWithAnnotation("GetAnno").single() as KSFunctionDeclaration
+        val getFunJava = javaList.getAllFunctions().single { it.simpleName.asString() == "get" }
+        val fooFunJava = javaList.getDeclaredFunctions().single { it.simpleName.asString() == "foo" }
+        val fooFunKt = resolver.getSymbolsWithAnnotation("FooAnno").single() as KSFunctionDeclaration
+        val foooFunKt = resolver.getSymbolsWithAnnotation("BarAnno").single() as KSFunctionDeclaration
+        val equalFunKt = kotlinList.getDeclaredFunctions().single { it.simpleName.asString() == "equals" }
+        val equalFunJava = javaList.getAllFunctions().single { it.simpleName.asString() == "equals" }
+        results.add("${getFunKt.qualifiedName?.asString()} overrides ${getFunJava.qualifiedName?.asString()}: ${getFunKt.overrides(getFunJava)}")
+        results.add("${fooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${fooFunKt.overrides(fooFunJava)}")
+        results.add("${foooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${foooFunKt.overrides(fooFunJava)}")
+        results.add("${equalFunKt.qualifiedName?.asString()} overrides ${equalFunJava.qualifiedName?.asString()}: ${equalFunKt.overrides(equalFunJava)}")
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ResolveJavaTypeProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ResolveJavaTypeProcessor.kt
@@ -18,11 +18,9 @@ class ResolveJavaTypeProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver) {
-        val annotated = resolver.getSymbolsWithAnnotation("Test")
-        (annotated.single() as KSClassDeclaration).superTypes
-            .map { it.resolve()?.declaration }
-            .filter { it?.origin == Origin.JAVA }
-            .map { it?.accept(visitor, Unit) }
+        val symbol = resolver.getClassDeclarationByName(resolver.getKSNameFromString("C"))
+        assert(symbol?.origin == Origin.JAVA)
+        symbol!!.accept(visitor, Unit)
     }
 
     inner class ResolveJavaTypeVisitor : KSTopDownVisitor<Unit, Unit>() {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -44,17 +44,11 @@ class KSFunctionDeclarationDescriptorImpl(val descriptor: FunctionDescriptor) : 
     }
 
     override fun overrides(overridee: KSFunctionDeclaration): Boolean {
-        if (!this.modifiers.contains(Modifier.OVERRIDE))
-            return false
         if (!overridee.isOpen())
             return false
         if (!overridee.isVisibleFrom(this))
             return false
-        val superDescriptor = if (overridee is KSFunctionDeclarationImpl) {
-            ResolverImpl.instance.resolveDeclaration(overridee.ktFunction) as FunctionDescriptor
-        } else {
-            (overridee as KSFunctionDeclarationDescriptorImpl).descriptor
-        }
+        val superDescriptor = ResolverImpl.instance.resolveFunctionDeclaration(overridee) ?: return false
         return OverridingUtil.DEFAULT.isOverridableBy(
             superDescriptor, descriptor, null
         ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
-import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSFunctionDeclarationDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.replaceTypeArguments
+import org.jetbrains.kotlin.ksp.symbol.impl.toKSFunctionDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.load.java.structure.impl.JavaClassImpl
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
@@ -60,7 +61,7 @@ class KSClassDeclarationJavaImpl(val psi: PsiClass) : KSClassDeclaration {
             it.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.FUNCTIONS)
                 .toList()
                 .filter { (it as FunctionDescriptor).visibility != Visibilities.INVISIBLE_FAKE }
-                .map { KSFunctionDeclarationDescriptorImpl.getCached(it as FunctionDescriptor) }
+                .map { (it as FunctionDescriptor).toKSFunctionDeclaration() }
         } ?: emptyList()
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -46,7 +46,7 @@ class KSClassDeclarationImpl(val ktClassOrObject: KtClassOrObject) : KSClassDecl
     override fun getAllFunctions(): List<KSFunctionDeclaration> {
         return descriptor.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.FUNCTIONS).toList()
             .filter { (it as FunctionDescriptor).visibility != Visibilities.INVISIBLE_FAKE }
-            .map { KSFunctionDeclarationDescriptorImpl.getCached(it as FunctionDescriptor) }
+            .map { (it as FunctionDescriptor).toKSFunctionDeclaration() }
     }
 
     override val declarations: List<KSDeclaration> by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -42,11 +42,7 @@ class KSFunctionDeclarationImpl(val ktFunction: KtFunction) : KSFunctionDeclarat
             return false
         if (!overridee.isVisibleFrom(this))
             return false
-        val superDescriptor = if (overridee is KSFunctionDeclarationImpl) {
-            ResolverImpl.instance.resolveDeclaration(overridee.ktFunction) as FunctionDescriptor
-        } else {
-            (overridee as KSFunctionDeclarationDescriptorImpl).descriptor
-        }
+        val superDescriptor = ResolverImpl.instance.resolveFunctionDeclaration(overridee) ?: return false
         val subDescriptor = ResolverImpl.instance.resolveDeclaration(ktFunction) as FunctionDescriptor
         return OverridingUtil.DEFAULT.isOverridableBy(
             superDescriptor, subDescriptor, null

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -11,7 +11,9 @@ import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.MemberDescriptor
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSFunctionDeclarationDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.java.KSClassDeclarationJavaImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
@@ -228,3 +230,12 @@ internal fun KotlinType.replaceTypeArguments(newArguments: List<KSTypeArgument>)
 
         TypeProjectionImpl(variance, type)
     })
+
+internal fun FunctionDescriptor.toKSFunctionDeclaration(): KSFunctionDeclaration {
+    val psi = this.findPsi() ?: return KSFunctionDeclarationDescriptorImpl.getCached(this)
+    return when (psi) {
+        is KtFunction -> KSFunctionDeclarationImpl.getCached(psi)
+        is PsiMethod -> KSFunctionDeclarationJavaImpl.getCached(psi)
+        else -> throw IllegalStateException("unexpected psi: ${psi.javaClass}")
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -114,11 +114,11 @@ fun MemberDescriptor.toKSModifiers(): Set<Modifier> {
     }
     when (this.visibility) {
         Visibilities.PUBLIC -> modifiers.add(Modifier.PUBLIC)
-        Visibilities.PROTECTED -> modifiers.add(Modifier.PROTECTED)
+        Visibilities.PROTECTED, JavaVisibilities.PROTECTED_AND_PACKAGE -> modifiers.add(Modifier.PROTECTED)
         Visibilities.PRIVATE -> modifiers.add(Modifier.PRIVATE)
         Visibilities.INTERNAL -> modifiers.add(Modifier.INTERNAL)
         // Since there is no modifier for package-private, use No modifier to tell if a symbol from binary is package private.
-        JavaVisibilities.PACKAGE_VISIBILITY -> Unit
+        JavaVisibilities.PACKAGE_VISIBILITY, JavaVisibilities.PROTECTED_STATIC_VISIBILITY -> Unit
         else -> throw IllegalStateException("unhandled visibility: ${this.visibility}")
     }
     return modifiers

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -43,6 +43,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/builtInTypes.kt");
     }
 
+    @TestMetadata("checkOverride.kt")
+    public void testCheckOverride() throws Exception {
+        runTest("plugins/ksp/testData/api/checkOverride.kt");
+    }
+
     @TestMetadata("companion.kt")
     public void testCompanion() throws Exception {
         runTest("plugins/ksp/testData/api/companion.kt");

--- a/plugins/ksp/testData/api/checkOverride.kt
+++ b/plugins/ksp/testData/api/checkOverride.kt
@@ -1,0 +1,49 @@
+// TEST PROCESSOR: CheckOverrideProcessor
+// EXPECTED:
+// KotlinList.get overrides JavaList.get: false
+// KotlinList.foo overrides JavaList.foo: true
+// KotlinList.fooo overrides JavaList.foo: false
+// KotlinList.equals overrides JavaList.equals: true
+// END
+// FILE: a.kt
+
+annotation class GetAnno
+annotation class FooAnno
+annotation class BarAnno
+
+
+class KotlinList: JavaList() {
+    @GetAnno
+    fun get(): Double {
+        return 2.0
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return false
+    }
+
+    @FooAnno
+    override fun foo(): Int {
+        return 2
+    }
+
+    @BarAnno
+    override fun fooo(): Int {
+        return 2
+    }
+}
+
+// FILE: JavaList.java
+
+import java.util.*;
+
+public class JavaList extends List<String> {
+    @Override
+    public String get(int index) {
+        return "OK";
+    }
+
+    protected int foo() {
+        return 1;
+    }
+}

--- a/plugins/ksp/testData/api/visibilities.kt
+++ b/plugins/ksp/testData/api/visibilities.kt
@@ -3,7 +3,7 @@
 // publicFun: PUBLIC,visible in A, B, D: true, true, true
 // packageFun: JAVA_PACKAGE,visible in A, B, D: true, false, true
 // privateFun: PRIVATE,visible in A, B, D: false, false, false
-// protectedFun: PROTECTED,visible in A, B, D: true, false, false
+// protectedFun: PROTECTED,visible in A, B, D: true, false, true
 // END
 
 // FILE: a.kt

--- a/plugins/ksp/testData/api/visibilities.kt
+++ b/plugins/ksp/testData/api/visibilities.kt
@@ -3,7 +3,7 @@
 // publicFun: PUBLIC,visible in A, B, D: true, true, true
 // packageFun: JAVA_PACKAGE,visible in A, B, D: true, false, true
 // privateFun: PRIVATE,visible in A, B, D: false, false, false
-// protectedFun: PROTECTED,visible in A, B, D: true, false, true
+// protectedFun: PROTECTED,visible in A, B, D: true, false, false
 // END
 
 // FILE: a.kt


### PR DESCRIPTION
Along with several minor fixes including:
* Fixed unhandled Java visibilities flag from deserialized descriptors.
* Fixed visibility checking for Java symbols, basically all but private members should be visible to package.
* Fixed getClassDeclarationByName to return result with correct origins, previously some results are returned as CLASS origin by mistake.
* Similar fix as above but for getAllFunctions().