### PR TITLE
add isAbstract for functions

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSFunctionDeclaration.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSFunctionDeclaration.kt
@@ -17,6 +17,11 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
     val functionKind: FunctionKind
 
     /**
+     * Whether this function is abstract.
+     */
+    val isAbstract: Boolean
+
+    /**
      * Extension receiver of this function
      * @see [https://kotlinlang.org/docs/reference/extensions.html#extension-functions]
      */

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DefaultFunctionProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DefaultFunctionProcessor.kt
@@ -18,7 +18,7 @@ class DefaultFunctionProcessor : AbstractTestProcessor() {
         val javaInterface = resolver.getClassDeclarationByName(resolver.getKSNameFromString("C")) as KSClassDeclaration
         result.addAll(checkFunctions(ktInterface, listOf("funLiteral", "funWithBody", "emptyFun")))
         result.addAll(checkFunctions(javaInterface, listOf("foo", "bar")))
-        val containsFun = ktInterface.getAllFunctions().single { it.simpleName.asString() == "contains" }
+        val containsFun = ktInterface.getAllFunctions().single { it.simpleName.asString() == "iterator" }
         result.add("${containsFun.simpleName.asString()}: ${containsFun.isAbstract}")
         val equalsFun = ktInterface.getAllFunctions().single { it.simpleName.asString() == "equals" }
         result.add("${equalsFun.simpleName.asString()}: ${equalsFun.isAbstract}")

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DefaultFunctionProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DefaultFunctionProcessor.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.getDeclaredFunctions
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.KSClassDeclaration
+
+class DefaultFunctionProcessor : AbstractTestProcessor() {
+
+    private val result = mutableListOf<String>()
+
+    override fun process(resolver: Resolver) {
+        val ktInterface = resolver.getClassDeclarationByName(resolver.getKSNameFromString("KTInterface")) as KSClassDeclaration
+        val javaInterface = resolver.getClassDeclarationByName(resolver.getKSNameFromString("C")) as KSClassDeclaration
+        result.addAll(checkFunctions(ktInterface, listOf("funLiteral", "funWithBody", "emptyFun")))
+        result.addAll(checkFunctions(javaInterface, listOf("foo", "bar")))
+        val containsFun = ktInterface.getAllFunctions().single { it.simpleName.asString() == "contains" }
+        result.add("${containsFun.simpleName.asString()}: ${containsFun.isAbstract}")
+        val equalsFun = ktInterface.getAllFunctions().single { it.simpleName.asString() == "equals" }
+        result.add("${equalsFun.simpleName.asString()}: ${equalsFun.isAbstract}")
+    }
+
+    private fun checkFunctions(classDec: KSClassDeclaration, funList: List<String>): List<String> {
+        return classDec.getDeclaredFunctions()
+            .filter { funList.contains(it.simpleName.asString()) }
+            .map { "${it.simpleName.asString()}: ${it.isAbstract}" }
+    }
+
+    override fun toResult(): List<String> {
+        return result
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -90,6 +90,10 @@ class KSFunctionDeclarationDescriptorImpl(val descriptor: FunctionDescriptor) : 
         }
     }
 
+    override val isAbstract: Boolean by lazy {
+        this.modifiers.contains(Modifier.ABSTRACT)
+    }
+
     override val modifiers: Set<Modifier> by lazy {
         val modifiers = mutableSetOf<Modifier>()
         modifiers.addAll(descriptor.toKSModifiers())

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -54,8 +54,13 @@ class KSFunctionDeclarationJavaImpl(val psi: PsiMethod) : KSFunctionDeclaration 
 
     override val extensionReceiver: KSTypeReference? = null
 
-
     override val functionKind: FunctionKind = if (psi.hasModifier(JvmModifier.STATIC)) FunctionKind.STATIC else FunctionKind.MEMBER
+
+    override val isAbstract: Boolean by lazy {
+        this.modifiers.contains(Modifier.ABSTRACT) ||
+                ((this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE &&
+                        !this.modifiers.contains(Modifier.JAVA_DEFAULT))
+    }
 
     override val modifiers: Set<Modifier> by lazy {
         psi.toKSModifiers()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -77,6 +77,12 @@ class KSFunctionDeclarationImpl(val ktFunction: KtFunction) : KSFunctionDeclarat
         }
     }
 
+    override val isAbstract: Boolean by lazy {
+        this.modifiers.contains(Modifier.ABSTRACT) ||
+                ((this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE
+                        && !this.ktFunction.hasBody())
+    }
+
     override val modifiers: Set<Modifier> by lazy {
         ktFunction.toKSModifiers()
     }

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -58,6 +58,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/hello.kt");
     }
 
+    @TestMetadata("interfaceWithDefault.kt")
+    public void testInterfaceWithDefault() throws Exception {
+        runTest("plugins/ksp/testData/api/interfaceWithDefault.kt");
+    }
+
     @TestMetadata("javaModifiers.kt")
     public void testJavaModifiers() throws Exception {
         runTest("plugins/ksp/testData/api/javaModifiers.kt");

--- a/plugins/ksp/testData/api/interfaceWithDefault.kt
+++ b/plugins/ksp/testData/api/interfaceWithDefault.kt
@@ -5,11 +5,11 @@
 // emptyFun: true
 // foo: false
 // bar: true
-// contains: true
+// iterator: true
 // equals: false
 // END
 // FILE: a.kt
-interface KTInterface: List<String> {
+interface KTInterface: Sequence<String> {
     fun funLiteral() = 1
 
     fun funWithBody(): Int {

--- a/plugins/ksp/testData/api/interfaceWithDefault.kt
+++ b/plugins/ksp/testData/api/interfaceWithDefault.kt
@@ -1,0 +1,30 @@
+// TEST PROCESSOR: DefaultFunctionProcessor
+// EXPECTED:
+// funLiteral: false
+// funWithBody: false
+// emptyFun: true
+// foo: false
+// bar: true
+// contains: true
+// equals: false
+// END
+// FILE: a.kt
+interface KTInterface: List<String> {
+    fun funLiteral() = 1
+
+    fun funWithBody(): Int {
+        return 1
+    }
+
+    fun emptyFun()
+
+}
+
+// FILE: C.java
+interface C {
+    default int foo() {
+        return 1;
+    }
+
+    int bar()
+}


### PR DESCRIPTION
I was thinking whether I should add this API to properties as well but decided not ~~as it is pretty trivia effort to check it by users, unlike for function this can be implicit~~ not trivia, but still wonder if it is necessary.