### PR TITLE
Make getAllSuperTypes() return a sequence

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
@@ -64,35 +64,35 @@ fun KSDeclaration.getVisibility(): Visibility {
  * get all super types for a class declaration
  * Calling [getAllSuperTypes] requires type resolution therefore is expensive and should be avoided if possible.
  */
-fun KSClassDeclaration.getAllSuperTypes(): Set<KSType> {
+fun KSClassDeclaration.getAllSuperTypes(): Sequence<KSType> {
 
-    fun KSTypeParameter.getTypesUpperBound(): List<KSClassDeclaration> =
-        this.bounds.flatMap {
+    fun KSTypeParameter.getTypesUpperBound(): Sequence<KSClassDeclaration> =
+        this.bounds.asSequence().flatMap {
             when (val resolvedDeclaration = it.resolve()?.declaration) {
-                is KSClassDeclaration -> listOf(resolvedDeclaration)
-                is KSTypeAlias -> listOf(resolvedDeclaration.findActualType())
+                is KSClassDeclaration -> sequenceOf(resolvedDeclaration)
+                is KSTypeAlias -> sequenceOf(resolvedDeclaration.findActualType())
                 is KSTypeParameter -> resolvedDeclaration.getTypesUpperBound()
                 else -> throw IllegalStateException()
             }
         }
 
-    val allSuperTypes = mutableSetOf<KSType>()
-    allSuperTypes.addAll(this.superTypes.mapNotNull { it.resolve() })
-
-    allSuperTypes.addAll(
-        this.superTypes
-            .mapNotNull { it.resolve()?.declaration }
-            .flatMap {
-                when (it) {
-                    is KSClassDeclaration -> it.getAllSuperTypes()
-                    is KSTypeAlias -> it.findActualType().getAllSuperTypes()
-                    is KSTypeParameter -> it.getTypesUpperBound().flatMap { it.getAllSuperTypes() }
-                    else -> throw IllegalStateException()
+    return this.superTypes
+        .asSequence()
+        .mapNotNull { it.resolve() }
+        .plus(
+            this.superTypes
+                .asSequence()
+                .mapNotNull { it.resolve()?.declaration }
+                .flatMap {
+                    when (it) {
+                        is KSClassDeclaration -> it.getAllSuperTypes()
+                        is KSTypeAlias -> it.findActualType().getAllSuperTypes()
+                        is KSTypeParameter -> it.getTypesUpperBound().flatMap { it.getAllSuperTypes() }
+                        else -> throw IllegalStateException()
+                    }
                 }
-            }
-    )
-
-    return allSuperTypes
+        )
+        .distinct()
 }
 
 fun KSDeclaration.isOpen() = !this.isLocal()


### PR DESCRIPTION
This allows for lazily resolving them and reduces potential expense