### PR TITLE
Fix KSAnnotation for Java symbols and support default argument evaluation

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
@@ -36,6 +36,8 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.*
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowInfo
+import org.jetbrains.kotlin.resolve.constants.ConstantValue
+import org.jetbrains.kotlin.resolve.constants.evaluate.ConstantExpressionEvaluator
 import org.jetbrains.kotlin.resolve.jvm.JavaDescriptorResolver
 import org.jetbrains.kotlin.resolve.lazy.DeclarationScopeProvider
 import org.jetbrains.kotlin.resolve.lazy.ResolveSession
@@ -57,6 +59,7 @@ class ResolverImpl(
     companion object {
         lateinit var resolveSession: ResolveSession
         lateinit var bodyResolver: BodyResolver
+        lateinit var constantExpressionEvaluator: ConstantExpressionEvaluator
         lateinit var declarationScopeProvider: DeclarationScopeProvider
         lateinit var topDownAnalyzer: LazyTopDownAnalyzer
         lateinit var instance: ResolverImpl
@@ -72,6 +75,7 @@ class ResolverImpl(
         declarationScopeProvider = componentProvider.get()
         topDownAnalyzer = componentProvider.get()
         javaDescriptorResolver = componentProvider.get()
+        constantExpressionEvaluator = componentProvider.get()
 
         ksFiles = files.map { KSFileImpl.getCached(it) }
         val javaResolverComponents = componentProvider.get<JavaResolverComponents>()
@@ -172,6 +176,10 @@ class ResolverImpl(
 
     override fun getKSNameFromString(name: String): KSName {
         return KSNameImpl.getCached(name)
+    }
+
+    fun evaluateConstant(expression: KtExpression?, expectedType: KotlinType): ConstantValue<*>? {
+        return expression?.let { constantExpressionEvaluator.evaluateToConstantValue(it, bindingTrace, expectedType) }
     }
 
     fun resolveDeclaration(declaration: KtDeclaration): DeclarationDescriptor? {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/AnnotationDefaultValueProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/AnnotationDefaultValueProcessor.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.processing.Resolver
+
+class AnnotationDefaultValueProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    override fun process(resolver: Resolver) {
+        val ktClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("A"))!!
+        var ktAnno = ktClass.annotations[0]
+        var javaAnno = ktClass.annotations[1]
+        result.add("${ktAnno.shortName.asString()} -> ${ktAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+        result.add("${javaAnno.shortName.asString()} -> ${javaAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+        val javaClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("JavaAnnotated"))!!
+        ktAnno = javaClass.annotations[0]
+        javaAnno = javaClass.annotations[1]
+        result.add("${ktAnno.shortName.asString()} -> ${ktAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+        result.add("${javaAnno.shortName.asString()} -> ${javaAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+    }
+}

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -38,6 +38,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/annotationValue.kt");
     }
 
+    @TestMetadata("annotationWithDefault.kt")
+    public void testAnnotationWithDefault() throws Exception {
+        runTest("plugins/ksp/testData/api/annotationWithDefault.kt");
+    }
+
     @TestMetadata("builtInTypes.kt")
     public void testBuiltInTypes() throws Exception {
         runTest("plugins/ksp/testData/api/builtInTypes.kt");

--- a/plugins/ksp/testData/api/annotationWithDefault.kt
+++ b/plugins/ksp/testData/api/annotationWithDefault.kt
@@ -1,0 +1,28 @@
+// TEST PROCESSOR: AnnotationDefaultValueProcessor
+// EXPECTED:
+// KotlinAnnotation -> a:debugKt,b:default
+// JavaAnnotation -> debug:debug,withDefaultValue:OK
+// KotlinAnnotation -> a:debugJava,b:default
+// JavaAnnotation -> debug:debugJava2,withDefaultValue:OK
+// END
+// FILE: a.kt
+
+annotation class KotlinAnnotation(val a: String, val b:String = "default")
+
+@KotlinAnnotation("debugKt")
+@JavaAnnotation("debug")
+class A
+
+// FILE: JavaAnnotation.java
+public @interface JavaAnnotation {
+    String debug();
+    String withDefaultValue()  default "OK";
+}
+
+// FILE: JavaAnnotated.java
+
+@KotlinAnnotation("debugJava")
+@JavaAnnotation("debugJava2")
+public class JavaAnnotated {
+
+}


### PR DESCRIPTION
* Fix implementation of KSAnnotationJavaImpl to use correct psi.
* Add support for digging into annotation class declaration to add default arguments missing from use site.