### PR TITLE
Clear object cache after processing

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/KotlinSymbolProcessingExtension.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/KotlinSymbolProcessingExtension.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.ksp.processing.SymbolProcessor
 import org.jetbrains.kotlin.ksp.processing.impl.CodeGeneratorImpl
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.processor.AbstractTestProcessor
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCacheManager
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.BindingTrace
@@ -77,6 +78,8 @@ abstract class AbstractKotlinSymbolProcessingExtension(val options: KspOptions, 
         processors.forEach {
             it.finish()
         }
+
+        KSObjectCacheManager.clear()
 
         return AnalysisResult.success(BindingContext.EMPTY, module, shouldGenerateCode = false)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/KSObjectCacheManager.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/KSObjectCacheManager.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.symbol.impl
+
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSAnnotationDescriptorImpl
+
+class KSObjectCacheManager {
+    companion object {
+        val caches = arrayListOf<KSObjectCache<*, *>>()
+
+        fun register(cache: KSObjectCache<*, *>) = caches.add(cache)
+        fun clear() = caches.forEach { it.clear() }
+    }
+}
+
+abstract class KSObjectCache<K, V> {
+    val cache = mutableMapOf<K, V>()
+
+    init {
+        KSObjectCacheManager.register(this)
+    }
+
+    open fun clear() = cache.clear()
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSValueArgumentLiteImpl
@@ -22,10 +23,8 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.resolve.constants.*
 
-class KSAnnotationDescriptorImpl(val descriptor: AnnotationDescriptor) : KSAnnotation {
-    companion object {
-        private val cache = mutableMapOf<AnnotationDescriptor, KSAnnotationDescriptorImpl>()
-
+class KSAnnotationDescriptorImpl private constructor(val descriptor: AnnotationDescriptor) : KSAnnotation {
+    companion object : KSObjectCache<AnnotationDescriptor, KSAnnotationDescriptorImpl>() {
         fun getCached(descriptor: AnnotationDescriptor) = cache.getOrPut(descriptor) { KSAnnotationDescriptorImpl(descriptor) }
     }
 
@@ -53,7 +52,7 @@ class KSAnnotationDescriptorImpl(val descriptor: AnnotationDescriptor) : KSAnnot
 }
 
 private fun ClassId.findKSClassDeclaration(): KSClassDeclaration? {
-    val ksName = KSNameImpl(this.asSingleFqName().asString())
+    val ksName = KSNameImpl.getCached(this.asSingleFqName().asString())
     return ResolverImpl.instance.getClassDeclarationByName(ksName)
 }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.binary
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSEnumEntryDeclarationImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
@@ -22,10 +23,8 @@ import org.jetbrains.kotlin.resolve.scopes.getDescriptorsFiltered
 import org.jetbrains.kotlin.types.typeUtil.replaceArgumentsWithStarProjections
 import org.jetbrains.kotlin.descriptors.ClassKind as KtClassKind
 
-class KSClassDeclarationDescriptorImpl(val descriptor: ClassDescriptor) : KSClassDeclaration {
-    companion object {
-        private val cache = mutableMapOf<ClassDescriptor, KSClassDeclarationDescriptorImpl>()
-
+class KSClassDeclarationDescriptorImpl private constructor(val descriptor: ClassDescriptor) : KSClassDeclaration {
+    companion object : KSObjectCache<ClassDescriptor, KSClassDeclarationDescriptorImpl>() {
         fun getCached(descriptor: ClassDescriptor) = cache.getOrPut(descriptor) { KSClassDeclarationDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
@@ -10,14 +10,13 @@ import org.jetbrains.kotlin.descriptors.ClassifierDescriptorWithTypeParameters
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
 import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeProjection
 
-class KSClassifierReferenceDescriptorImpl(val descriptor: ClassifierDescriptor, val arguments: List<TypeProjection>) :
+class KSClassifierReferenceDescriptorImpl private constructor(val descriptor: ClassifierDescriptor, val arguments: List<TypeProjection>) :
     KSClassifierReference {
-    companion object {
-        private val cache = mutableMapOf<Pair<ClassifierDescriptor, List<TypeProjection>>, KSClassifierReferenceDescriptorImpl>()
-
+    companion object : KSObjectCache<Pair<ClassifierDescriptor, List<TypeProjection>>, KSClassifierReferenceDescriptorImpl>() {
         fun getCached(kotlinType: KotlinType) = cache.getOrPut(
             Pair(
                 kotlinType.constructor.declarationDescriptor!!,

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSEnumEntryDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSEnumEntryDeclarationDescriptorImpl.kt
@@ -7,12 +7,12 @@ package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
-class KSEnumEntryDeclarationDescriptorImpl(val descriptor: ClassDescriptor) : KSEnumEntryDeclaration,
+class KSEnumEntryDeclarationDescriptorImpl private constructor(val descriptor: ClassDescriptor) : KSEnumEntryDeclaration,
     KSClassDeclaration by KSClassDeclarationDescriptorImpl.getCached(descriptor) {
-    companion object {
-        val cache = mutableMapOf<ClassDescriptor, KSEnumEntryDeclarationDescriptorImpl>()
+    companion object : KSObjectCache<ClassDescriptor, KSEnumEntryDeclarationDescriptorImpl>() {
         fun getCached(descriptor: ClassDescriptor) = cache.getOrPut(descriptor) { KSEnumEntryDeclarationDescriptorImpl(descriptor) }
     }
 }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -19,10 +19,8 @@ import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 
-class KSFunctionDeclarationDescriptorImpl(val descriptor: FunctionDescriptor) : KSFunctionDeclaration {
-    companion object {
-        private val cache = mutableMapOf<FunctionDescriptor, KSFunctionDeclarationDescriptorImpl>()
-
+class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: FunctionDescriptor) : KSFunctionDeclaration {
+    companion object : KSObjectCache<FunctionDescriptor, KSFunctionDeclarationDescriptorImpl>() {
         fun getCached(descriptor: FunctionDescriptor) = cache.getOrPut(descriptor) { KSFunctionDeclarationDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -16,10 +16,8 @@ import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 
-class KSPropertyDeclarationDescriptorImpl(val descriptor: VariableDescriptorWithAccessors) : KSPropertyDeclaration {
-    companion object {
-        private val cache = mutableMapOf<VariableDescriptorWithAccessors, KSPropertyDeclarationDescriptorImpl>()
-
+class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: VariableDescriptorWithAccessors) : KSPropertyDeclaration {
+    companion object : KSObjectCache<VariableDescriptorWithAccessors, KSPropertyDeclarationDescriptorImpl>() {
         fun getCached(descriptor: VariableDescriptorWithAccessors) = cache.getOrPut(descriptor) { KSPropertyDeclarationDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
@@ -7,13 +7,12 @@ package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.descriptors.PropertyGetterDescriptor
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toFunctionKSModifiers
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 
-class KSPropertyGetterDescriptorImpl(val descriptor: PropertyGetterDescriptor) : KSPropertyGetter {
-    companion object {
-        private val cache = mutableMapOf<PropertyGetterDescriptor, KSPropertyGetterDescriptorImpl>()
-
+class KSPropertyGetterDescriptorImpl private constructor(val descriptor: PropertyGetterDescriptor) : KSPropertyGetter {
+    companion object : KSObjectCache<PropertyGetterDescriptor, KSPropertyGetterDescriptorImpl>() {
         fun getCached(descriptor: PropertyGetterDescriptor) = cache.getOrPut(descriptor) { KSPropertyGetterDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
@@ -7,13 +7,12 @@ package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.descriptors.PropertySetterDescriptor
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toFunctionKSModifiers
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 
-class KSPropertySetterDescriptorImpl(val descriptor: PropertySetterDescriptor) : KSPropertySetter {
-    companion object {
-        private val cache = mutableMapOf<PropertySetterDescriptor, KSPropertySetterDescriptorImpl>()
-
+class KSPropertySetterDescriptorImpl private constructor(val descriptor: PropertySetterDescriptor) : KSPropertySetter {
+    companion object : KSObjectCache<PropertySetterDescriptor, KSPropertySetterDescriptorImpl>() {
         fun getCached(descriptor: PropertySetterDescriptor) = cache.getOrPut(descriptor) { KSPropertySetterDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
@@ -6,13 +6,12 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
 import org.jetbrains.kotlin.types.TypeProjection
 
-class KSTypeArgumentDescriptorImpl(val descriptor: TypeProjection) : KSTypeArgumentImpl() {
-    companion object {
-        private val cache = mutableMapOf<TypeProjection, KSTypeArgumentDescriptorImpl>()
-
+class KSTypeArgumentDescriptorImpl private constructor(val descriptor: TypeProjection) : KSTypeArgumentImpl() {
+    companion object : KSObjectCache<TypeProjection, KSTypeArgumentDescriptorImpl>() {
         fun getCached(descriptor: TypeProjection) = cache.getOrPut(descriptor) { KSTypeArgumentDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
@@ -10,14 +10,13 @@ import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSVariance
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
-class KSTypeParameterDescriptorImpl(val descriptor: TypeParameterDescriptor) : KSTypeParameter {
-    companion object {
-        private val cache = mutableMapOf<TypeParameterDescriptor, KSTypeParameterDescriptorImpl>()
-
+class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypeParameterDescriptor) : KSTypeParameter {
+    companion object : KSObjectCache<TypeParameterDescriptor, KSTypeParameterDescriptorImpl>() {
         fun getCached(descriptor: TypeParameterDescriptor) = cache.getOrPut(descriptor) { KSTypeParameterDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
@@ -11,12 +11,11 @@ import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 import org.jetbrains.kotlin.ksp.symbol.Modifier
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.types.*
 
-class KSTypeReferenceDescriptorImpl(val kotlinType: KotlinType) : KSTypeReference {
-    companion object {
-        private val cache = mutableMapOf<KotlinType, KSTypeReferenceDescriptorImpl>()
-
+class KSTypeReferenceDescriptorImpl private constructor(val kotlinType: KotlinType) : KSTypeReference {
+    companion object : KSObjectCache<KotlinType, KSTypeReferenceDescriptorImpl>() {
         fun getCached(kotlinType: KotlinType) = cache.getOrPut(kotlinType) { KSTypeReferenceDescriptorImpl(kotlinType) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSVariableParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSVariableParameterDescriptorImpl.kt
@@ -7,14 +7,13 @@ package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.resolve.calls.components.isVararg
 
-class KSVariableParameterDescriptorImpl(val descriptor: ValueParameterDescriptor) : KSVariableParameter {
-    companion object {
-        private val cache = mutableMapOf<ValueParameterDescriptor, KSVariableParameterDescriptorImpl>()
-
+class KSVariableParameterDescriptorImpl private constructor(val descriptor: ValueParameterDescriptor) : KSVariableParameter {
+    companion object : KSObjectCache<ValueParameterDescriptor, KSVariableParameterDescriptorImpl>() {
         fun getCached(descriptor: ValueParameterDescriptor) = cache.getOrPut(descriptor) { KSVariableParameterDescriptorImpl(descriptor) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -11,14 +11,13 @@ import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiClass
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.getAbsentDefaultArguments
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 
-class KSAnnotationJavaImpl(val psi: PsiAnnotation) : KSAnnotation {
-    companion object {
-        private val cache = mutableMapOf<PsiAnnotation, KSAnnotationJavaImpl>()
-
+class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnotation {
+    companion object : KSObjectCache<PsiAnnotation, KSAnnotationJavaImpl>() {
         fun getCached(psi: PsiAnnotation) = cache.getOrPut(psi) { KSAnnotationJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -12,21 +12,18 @@ import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
-import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
+import org.jetbrains.kotlin.ksp.symbol.impl.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.replaceTypeArguments
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSFunctionDeclaration
-import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.load.java.structure.impl.JavaClassImpl
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.getDescriptorsFiltered
 import org.jetbrains.kotlin.types.typeUtil.replaceArgumentsWithStarProjections
 
-class KSClassDeclarationJavaImpl(val psi: PsiClass) : KSClassDeclaration {
-    companion object {
-        private val cache = mutableMapOf<PsiClass, KSClassDeclarationJavaImpl>()
-
+class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) : KSClassDeclaration {
+    companion object : KSObjectCache<PsiClass, KSClassDeclarationJavaImpl>() {
         fun getCached(psi: PsiClass) = cache.getOrPut(psi) { KSClassDeclarationJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
@@ -11,11 +11,10 @@ import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
 import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 
-class KSClassifierReferenceJavaImpl(val psi: PsiClassType) : KSClassifierReference {
-    companion object {
-        private val cache = mutableMapOf<PsiClassType, KSClassifierReferenceJavaImpl>()
-
+class KSClassifierReferenceJavaImpl private constructor(val psi: PsiClassType) : KSClassifierReference {
+    companion object : KSObjectCache<PsiClassType, KSClassifierReferenceJavaImpl>() {
         fun getCached(psi: PsiClassType) = cache.getOrPut(psi) { KSClassifierReferenceJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFileJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFileJavaImpl.kt
@@ -7,12 +7,11 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 
 import com.intellij.psi.PsiJavaFile
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 
-class KSFileJavaImpl(val psi: PsiJavaFile) : KSFile {
-    companion object {
-        private val cache = mutableMapOf<PsiJavaFile, KSFileJavaImpl>()
-
+class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile {
+    companion object : KSObjectCache<PsiJavaFile, KSFileJavaImpl>() {
         fun getCached(psi: PsiJavaFile) = cache.getOrPut(psi) { KSFileJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.ksp.isOpen
 import org.jetbrains.kotlin.ksp.isVisibleFrom
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSFunctionDeclarationDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSFunctionDeclarationImpl
@@ -20,10 +21,8 @@ import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
-class KSFunctionDeclarationJavaImpl(val psi: PsiMethod) : KSFunctionDeclaration {
-    companion object {
-        private val cache = mutableMapOf<PsiMethod, KSFunctionDeclarationJavaImpl>()
-
+class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KSFunctionDeclaration {
+    companion object : KSObjectCache<PsiMethod, KSFunctionDeclarationJavaImpl>() {
         fun getCached(psi: PsiMethod) = cache.getOrPut(psi) { KSFunctionDeclarationJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -12,15 +12,14 @@ import org.jetbrains.kotlin.ksp.isOpen
 import org.jetbrains.kotlin.ksp.isVisibleFrom
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
-class KSPropertyDeclarationJavaImpl(val psi: PsiField) : KSPropertyDeclaration {
-    companion object {
-        private val cache = mutableMapOf<PsiField, KSPropertyDeclarationJavaImpl>()
-
+class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSPropertyDeclaration {
+    companion object : KSObjectCache<PsiField, KSPropertyDeclarationJavaImpl>() {
         fun getCached(psi: PsiField) = cache.getOrPut(psi) { KSPropertyDeclarationJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
@@ -8,12 +8,11 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiWildcardType
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
 
-class KSTypeArgumentJavaImpl(val psi: PsiType) : KSTypeArgumentImpl() {
-    companion object {
-        private val cache = mutableMapOf<PsiType, KSTypeArgumentJavaImpl>()
-
+class KSTypeArgumentJavaImpl private constructor(val psi: PsiType) : KSTypeArgumentImpl() {
+    companion object : KSObjectCache<PsiType, KSTypeArgumentJavaImpl>() {
         fun getCached(psi: PsiType) = cache.getOrPut(psi) { KSTypeArgumentJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
@@ -8,13 +8,12 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiTypeParameter
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 
-class KSTypeParameterJavaImpl(val psi: PsiTypeParameter) : KSTypeParameter {
-    companion object {
-        private val cache = mutableMapOf<PsiTypeParameter, KSTypeParameterJavaImpl>()
-
+class KSTypeParameterJavaImpl private constructor(val psi: PsiTypeParameter) : KSTypeParameter {
+    companion object : KSObjectCache<PsiTypeParameter, KSTypeParameterJavaImpl>() {
         fun getCached(psi: PsiTypeParameter) = cache.getOrPut(psi) { KSTypeParameterJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -8,14 +8,13 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 import com.intellij.psi.*
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSClassifierReferenceDescriptorImpl
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.Variance
 
-class KSTypeReferenceJavaImpl(val psi: PsiType) : KSTypeReference {
-    companion object {
-        private val cache = mutableMapOf<PsiType, KSTypeReferenceJavaImpl>()
-
+class KSTypeReferenceJavaImpl private constructor(val psi: PsiType) : KSTypeReference {
+    companion object : KSObjectCache<PsiType, KSTypeReferenceJavaImpl>() {
         fun getCached(psi: PsiType) = cache.getOrPut(psi) { KSTypeReferenceJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
@@ -6,11 +6,10 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.java
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 
-class KSTypeReferenceLiteJavaImpl(val type: KSType) : KSTypeReference {
-    companion object {
-        private val cache = mutableMapOf<KSType, KSTypeReferenceLiteJavaImpl>()
-
+class KSTypeReferenceLiteJavaImpl private constructor(val type: KSType) : KSTypeReference {
+    companion object : KSObjectCache<KSType, KSTypeReferenceLiteJavaImpl>() {
         fun getCached(type: KSType) = cache.getOrPut(type) { KSTypeReferenceLiteJavaImpl(type) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSValueArgumentJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSValueArgumentJavaImpl.kt
@@ -8,12 +8,11 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 import org.jetbrains.kotlin.ksp.symbol.KSAnnotation
 import org.jetbrains.kotlin.ksp.symbol.KSName
 import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSValueArgumentImpl
 
-class KSValueArgumentJavaImpl(override val name: KSName?, override val value: Any?) : KSValueArgumentImpl() {
-    companion object {
-        private val cache = mutableMapOf<Pair<KSName?, Any?>, KSValueArgumentJavaImpl>()
-
+class KSValueArgumentJavaImpl private constructor(override val name: KSName?, override val value: Any?) : KSValueArgumentImpl() {
+    companion object : KSObjectCache<Pair<KSName?, Any?>, KSValueArgumentJavaImpl>() {
         fun getCached(name: KSName?, value: Any?) = cache.getOrPut(Pair(name, value)) { KSValueArgumentJavaImpl(name, value) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSVariableParameterJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSVariableParameterJavaImpl.kt
@@ -7,12 +7,11 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 
 import com.intellij.psi.PsiParameter
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 
-class KSVariableParameterJavaImpl(val psi: PsiParameter) : KSVariableParameter {
-    companion object {
-        private val cache = mutableMapOf<PsiParameter, KSVariableParameterJavaImpl>()
-
+class KSVariableParameterJavaImpl private constructor(val psi: PsiParameter) : KSVariableParameter {
+    companion object : KSObjectCache<PsiParameter, KSVariableParameterJavaImpl>() {
         fun getCached(psi: PsiParameter) = cache.getOrPut(psi) { KSVariableParameterJavaImpl(psi) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -8,13 +8,12 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.createKSValueArguments
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 
-class KSAnnotationImpl(val ktAnnotationEntry: KtAnnotationEntry) : KSAnnotation {
-    companion object {
-        private val cache = mutableMapOf<KtAnnotationEntry, KSAnnotationImpl>()
-
+class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEntry) : KSAnnotation {
+    companion object : KSObjectCache<KtAnnotationEntry, KSAnnotationImpl>() {
         fun getCached(ktAnnotationEntry: KtAnnotationEntry) = cache.getOrPut(ktAnnotationEntry) { KSAnnotationImpl(ktAnnotationEntry) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSCallableReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSCallableReferenceImpl.kt
@@ -6,12 +6,11 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtFunctionType
 
-class KSCallableReferenceImpl(val ktFunctionType: KtFunctionType) : KSCallableReference {
-    companion object {
-        private val cache = mutableMapOf<KtFunctionType, KSCallableReferenceImpl>()
-
+class KSCallableReferenceImpl private constructor(val ktFunctionType: KtFunctionType) : KSCallableReference {
+    companion object : KSObjectCache<KtFunctionType, KSCallableReferenceImpl>() {
         fun getCached(ktFunctionType: KtFunctionType) = cache.getOrPut(ktFunctionType) { KSCallableReferenceImpl(ktFunctionType) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -18,10 +18,8 @@ import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.getDescriptorsFiltered
 import org.jetbrains.kotlin.types.typeUtil.replaceArgumentsWithStarProjections
 
-class KSClassDeclarationImpl(val ktClassOrObject: KtClassOrObject) : KSClassDeclaration {
-    companion object {
-        private val cache = mutableMapOf<KtClassOrObject, KSClassDeclarationImpl>()
-
+class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrObject) : KSClassDeclaration {
+    companion object : KSObjectCache<KtClassOrObject, KSClassDeclarationImpl>() {
         fun getCached(ktClassOrObject: KtClassOrObject) = cache.getOrPut(ktClassOrObject) { KSClassDeclarationImpl(ktClassOrObject) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
@@ -8,12 +8,11 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
 import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.*
 
-class KSClassifierReferenceImpl(val ktUserType: KtUserType) : KSClassifierReference {
-    companion object {
-        private val cache = mutableMapOf<KtUserType, KSClassifierReferenceImpl>()
-
+class KSClassifierReferenceImpl private constructor(val ktUserType: KtUserType) : KSClassifierReference {
+    companion object : KSObjectCache<KtUserType, KSClassifierReferenceImpl>() {
         fun getCached(ktUserType: KtUserType) = cache.getOrPut(ktUserType) { KSClassifierReferenceImpl(ktUserType) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
@@ -9,11 +9,12 @@ import org.jetbrains.kotlin.ksp.symbol.KSDynamicReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
 import org.jetbrains.kotlin.ksp.symbol.KSVisitor
 import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.psi.KtUserType
 
-class KSDynamicReferenceImpl : KSDynamicReference {
-    companion object {
-        private val cache = KSDynamicReferenceImpl()
-        fun getCached() = cache
+class KSDynamicReferenceImpl private constructor() : KSDynamicReference {
+    companion object : KSObjectCache<Unit, KSDynamicReferenceImpl>() {
+        fun getCached(unused: Unit) = cache.getOrPut(unused) { KSDynamicReferenceImpl() }
     }
 
     override val origin = Origin.KOTLIN

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSEnumEntryDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSEnumEntryDeclarationImpl.kt
@@ -6,12 +6,12 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
-class KSEnumEntryDeclarationImpl(ktClassOrObject: KtClassOrObject) : KSEnumEntryDeclaration,
+class KSEnumEntryDeclarationImpl private constructor(ktClassOrObject: KtClassOrObject) : KSEnumEntryDeclaration,
     KSClassDeclaration by KSClassDeclarationImpl.getCached(ktClassOrObject) {
-    companion object {
-        val cache = mutableMapOf<KtClassOrObject, KSEnumEntryDeclarationImpl>()
+    companion object : KSObjectCache<KtClassOrObject, KSEnumEntryDeclarationImpl>() {
         fun getCached(ktClassOrObject: KtClassOrObject) = cache.getOrPut(ktClassOrObject) { KSEnumEntryDeclarationImpl(ktClassOrObject) }
     }
 }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFileImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFileImpl.kt
@@ -6,13 +6,12 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.getKSDeclarations
 import org.jetbrains.kotlin.psi.KtFile
 
-class KSFileImpl(val file: KtFile) : KSFile {
-    companion object {
-        private val cache = mutableMapOf<KtFile, KSFileImpl>()
-
+class KSFileImpl private constructor(val file: KtFile) : KSFile {
+    companion object : KSObjectCache<KtFile, KSFileImpl>() {
         fun getCached(file: KtFile) = cache.getOrPut(file) { KSFileImpl(file) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -18,10 +18,8 @@ import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.calls.inference.returnTypeOrNothing
 import java.lang.IllegalStateException
 
-class KSFunctionDeclarationImpl(val ktFunction: KtFunction) : KSFunctionDeclaration {
-    companion object {
-        private val cache = mutableMapOf<KtFunction, KSFunctionDeclarationImpl>()
-
+class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) : KSFunctionDeclaration {
+    companion object : KSObjectCache<KtFunction, KSFunctionDeclarationImpl>() {
         fun getCached(ktFunction: KtFunction) = cache.getOrPut(ktFunction) { KSFunctionDeclarationImpl(ktFunction) }
     }
 
@@ -103,7 +101,7 @@ class KSFunctionDeclarationImpl(val ktFunction: KtFunction) : KSFunctionDeclarat
         if (ktFunction.typeReference != null) {
             KSTypeReferenceImpl.getCached(ktFunction.typeReference!!)
         } else {
-            KSTypeReferenceDeferredImpl {
+            KSTypeReferenceDeferredImpl.getCached {
                 val desc = ResolverImpl.instance.resolveDeclaration(ktFunction) as FunctionDescriptor
                 KSTypeImpl.getCached(desc.returnTypeOrNothing)
             }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSNameImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSNameImpl.kt
@@ -6,11 +6,10 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.KSName
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 
-class KSNameImpl(val name: String) : KSName {
-    companion object {
-        private val cache = mutableMapOf<String, KSNameImpl>()
-
+class KSNameImpl private constructor(val name: String) : KSName {
+    companion object : KSObjectCache<String, KSNameImpl>() {
         fun getCached(name: String) = cache.getOrPut(name) { KSNameImpl(name) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -17,10 +17,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.calls.inference.returnTypeOrNothing
 
-class KSPropertyDeclarationImpl(val ktProperty: KtProperty) : KSPropertyDeclaration {
-    companion object {
-        private val cache = mutableMapOf<KtProperty, KSPropertyDeclarationImpl>()
-
+class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) : KSPropertyDeclaration {
+    companion object : KSObjectCache<KtProperty, KSPropertyDeclarationImpl>() {
         fun getCached(ktProperty: KtProperty) = cache.getOrPut(ktProperty) { KSPropertyDeclarationImpl(ktProperty) }
     }
 
@@ -84,7 +82,7 @@ class KSPropertyDeclarationImpl(val ktProperty: KtProperty) : KSPropertyDeclarat
         if (ktProperty.typeReference != null) {
             KSTypeReferenceImpl.getCached(ktProperty.typeReference!!)
         } else {
-            KSTypeReferenceDeferredImpl {
+            KSTypeReferenceDeferredImpl.getCached {
                 val desc = ResolverImpl.instance.resolveDeclaration(ktProperty) as? VariableDescriptorWithAccessors
                 if (desc == null) {
                     // TODO: Add error type to allow forward reference being taken care of.

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.ksp.isOpen
 import org.jetbrains.kotlin.ksp.isVisibleFrom
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -17,10 +18,8 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtStubbedPsiUtil
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
-class KSPropertyDeclarationParameterImpl(val ktParameter: KtParameter) : KSPropertyDeclaration {
-    companion object {
-        private val cache = mutableMapOf<KtParameter, KSPropertyDeclarationParameterImpl>()
-
+class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: KtParameter) : KSPropertyDeclaration {
+    companion object : KSObjectCache<KtParameter, KSPropertyDeclarationParameterImpl>() {
         fun getCached(ktParameter: KtParameter) = cache.getOrPut(ktParameter) { KSPropertyDeclarationParameterImpl(ktParameter) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
@@ -8,14 +8,13 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 
-class KSPropertyGetterImpl(val ktPropertyGetter: KtPropertyAccessor) : KSPropertyGetter {
-    companion object {
-        private val cache = mutableMapOf<KtPropertyAccessor, KSPropertyGetterImpl>()
-
+class KSPropertyGetterImpl private constructor(val ktPropertyGetter: KtPropertyAccessor) : KSPropertyGetter {
+    companion object : KSObjectCache<KtPropertyAccessor, KSPropertyGetterImpl>() {
         fun getCached(ktPropertyGetter: KtPropertyAccessor) = cache.getOrPut(ktPropertyGetter) { KSPropertyGetterImpl(ktPropertyGetter) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
@@ -6,13 +6,12 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 
-class KSPropertySetterImpl(val ktPropertySetter: KtPropertyAccessor) : KSPropertySetter {
-    companion object {
-        private val cache = mutableMapOf<KtPropertyAccessor, KSPropertySetterImpl>()
-
+class KSPropertySetterImpl private constructor(val ktPropertySetter: KtPropertyAccessor) : KSPropertySetter {
+    companion object : KSObjectCache<KtPropertyAccessor, KSPropertySetterImpl>() {
         fun getCached(ktPropertySetter: KtPropertyAccessor) = cache.getOrPut(ktPropertySetter) { KSPropertySetterImpl(ktPropertySetter) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
@@ -6,14 +6,13 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.psi.*
 
-class KSTypeAliasImpl(val ktTypeAlias: KtTypeAlias) : KSTypeAlias {
-    companion object {
-        private val cache = mutableMapOf<KtTypeAlias, KSTypeAliasImpl>()
-
+class KSTypeAliasImpl private constructor(val ktTypeAlias: KtTypeAlias) : KSTypeAlias {
+    companion object : KSObjectCache<KtTypeAlias, KSTypeAliasImpl>() {
         fun getCached(ktTypeAlias: KtTypeAlias) = cache.getOrPut(ktTypeAlias) { KSTypeAliasImpl(ktTypeAlias) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentImpl.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtProjectionKind
 import org.jetbrains.kotlin.psi.KtTypeProjection
 
@@ -26,10 +27,8 @@ abstract class KSTypeArgumentImpl : KSTypeArgument {
     }
 }
 
-class KSTypeArgumentKtImpl(val ktTypeArgument: KtTypeProjection) : KSTypeArgumentImpl() {
-    companion object {
-        private val cache = mutableMapOf<KtTypeProjection, KSTypeArgumentKtImpl>()
-
+class KSTypeArgumentKtImpl private constructor(val ktTypeArgument: KtTypeProjection) : KSTypeArgumentImpl() {
+    companion object : KSObjectCache<KtTypeProjection, KSTypeArgumentKtImpl>() {
         fun getCached(ktTypeArgument: KtTypeProjection) = cache.getOrPut(ktTypeArgument) { KSTypeArgumentKtImpl(ktTypeArgument) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentLiteImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentLiteImpl.kt
@@ -6,12 +6,11 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtTypeReference
 
-class KSTypeArgumentLiteImpl(override val type: KSTypeReference, override val variance: Variance) : KSTypeArgumentImpl() {
-    companion object {
-        private val cache = mutableMapOf<Pair<KSTypeReference, Variance>, KSTypeArgumentLiteImpl>()
-
+class KSTypeArgumentLiteImpl private constructor(override val type: KSTypeReference, override val variance: Variance) : KSTypeArgumentImpl() {
+    companion object : KSObjectCache<Pair<KSTypeReference, Variance>, KSTypeArgumentLiteImpl>() {
         fun getCached(type: KSTypeReference, variance: Variance) = cache.getOrPut(Pair(type, variance)) {
             KSTypeArgumentLiteImpl(type, variance)
         }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -7,19 +7,18 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.replaceTypeArguments
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.*
 
-class KSTypeImpl(
+class KSTypeImpl private constructor(
     val kotlinType: KotlinType,
     private val ksTypeArguments: List<KSTypeArgument>? = null,
     override val annotations: List<KSAnnotation> = listOf()
 ) : KSType {
-    companion object {
-        private val cache = mutableMapOf<KotlinType, KSTypeImpl>()
-
+    companion object : KSObjectCache<KotlinType, KSTypeImpl>() {
         fun getCached(
             kotlinType: KotlinType,
             ksTypeArguments: List<KSTypeArgument>? = null,

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
@@ -6,15 +6,14 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
-class KSTypeParameterImpl(val ktTypeParameter: KtTypeParameter, val owner: KtTypeParameterListOwner) : KSTypeParameter {
-    companion object {
-        private val cache = mutableMapOf<Pair<KtTypeParameter, KtTypeParameterListOwner>, KSTypeParameterImpl>()
-
+class KSTypeParameterImpl private constructor(val ktTypeParameter: KtTypeParameter, val owner: KtTypeParameterListOwner) : KSTypeParameter {
+    companion object : KSObjectCache<Pair<KtTypeParameter, KtTypeParameterListOwner>, KSTypeParameterImpl>() {
         fun getCached(ktTypeParameter: KtTypeParameter, owner: KtTypeParameterListOwner) = cache.getOrPut(Pair(ktTypeParameter, owner)) { KSTypeParameterImpl(ktTypeParameter, owner) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceDeferredImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceDeferredImpl.kt
@@ -6,11 +6,10 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 
-class KSTypeReferenceDeferredImpl(private val resolver: () -> KSType?) : KSTypeReference {
-    companion object {
-        private val cache = mutableMapOf<() -> KSType?, KSTypeReferenceDeferredImpl>()
-
+class KSTypeReferenceDeferredImpl private constructor(private val resolver: () -> KSType?) : KSTypeReference {
+    companion object : KSObjectCache<() -> KSType?, KSTypeReferenceDeferredImpl>() {
         fun getCached(resolver: () -> KSType?) = cache.getOrPut(resolver) { KSTypeReferenceDeferredImpl(resolver) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
@@ -7,14 +7,13 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.psi.*
 import java.lang.IllegalStateException
 
-class KSTypeReferenceImpl(val ktTypeReference: KtTypeReference) : KSTypeReference {
-    companion object {
-        private val cache = mutableMapOf<KtTypeReference, KSTypeReferenceImpl>()
-
+class KSTypeReferenceImpl private constructor(val ktTypeReference: KtTypeReference) : KSTypeReference {
+    companion object : KSObjectCache<KtTypeReference, KSTypeReferenceImpl>() {
         fun getCached(ktTypeReference: KtTypeReference) = cache.getOrPut(ktTypeReference) { KSTypeReferenceImpl(ktTypeReference) }
     }
 
@@ -35,7 +34,7 @@ class KSTypeReferenceImpl(val ktTypeReference: KtTypeReference) : KSTypeReferenc
         when (typeElement) {
             is KtFunctionType -> KSCallableReferenceImpl.getCached(typeElement)
             is KtUserType -> KSClassifierReferenceImpl.getCached(typeElement)
-            is KtDynamicType -> KSDynamicReferenceImpl.getCached()
+            is KtDynamicType -> KSDynamicReferenceImpl.getCached(Unit)
             else -> throw IllegalStateException()
         }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSValueArgumentImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSValueArgumentImpl.kt
@@ -6,11 +6,10 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 
-class KSValueArgumentLiteImpl(override val name: KSName, override val value: Any?) : KSValueArgumentImpl() {
-    companion object {
-        private val cache = mutableMapOf<Pair<KSName, Any?>, KSValueArgumentLiteImpl>()
-
+class KSValueArgumentLiteImpl private constructor(override val name: KSName, override val value: Any?) : KSValueArgumentImpl() {
+    companion object : KSObjectCache<Pair<KSName, Any?>, KSValueArgumentLiteImpl>() {
         fun getCached(name: KSName, value: Any?) = cache.getOrPut(Pair(name, value)) { KSValueArgumentLiteImpl(name, value) }
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSVariableParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSVariableParameterImpl.kt
@@ -6,14 +6,13 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.lexer.KtTokens.CROSSINLINE_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.NOINLINE_KEYWORD
 import org.jetbrains.kotlin.psi.KtParameter
 
-class KSVariableParameterImpl(val ktParameter: KtParameter) : KSVariableParameter {
-    companion object {
-        private val cache = mutableMapOf<KtParameter, KSVariableParameterImpl>()
-
+class KSVariableParameterImpl private constructor(val ktParameter: KtParameter) : KSVariableParameter {
+    companion object : KSObjectCache<KtParameter, KSVariableParameterImpl>() {
         fun getCached(ktParameter: KtParameter) = cache.getOrPut(ktParameter) { KSVariableParameterImpl(ktParameter) }
     }
 


### PR DESCRIPTION
For multiple rounds and testing. Also marked all constructors private.