### PR TITLE
Organize output directories to conform to Gradle convention

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/KotlinSymbolProcessingExtension.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/KotlinSymbolProcessingExtension.kt
@@ -65,8 +65,12 @@ abstract class AbstractKotlinSymbolProcessingExtension(val options: KspOptions, 
             .distinctBy { it.canonicalPath }
             .mapNotNull { localFileSystem.findFileByPath(it.path)?.let { psiManager.findFile(it) } as? PsiJavaFile }
         val resolver = ResolverImpl(module, files, javaFiles, bindingTrace, componentProvider)
-        val targetDir = options.sourcesOutputDir
-        val codeGen = CodeGeneratorImpl(targetDir)
+        val codeGen = CodeGeneratorImpl(
+            options.classOutputDir,
+            options.javaOutputDir,
+            options.kotlinOutputDir,
+            options.resourceOutputDir
+        )
 
         val processors = loadProcessors()
         processors.forEach {
@@ -103,8 +107,8 @@ abstract class AbstractKotlinSymbolProcessingExtension(val options: KspOptions, 
         return AnalysisResult.RetryWithAdditionalRoots(
             BindingContext.EMPTY,
             module,
-            listOf(options.sourcesOutputDir),
-            listOf(options.sourcesOutputDir),
+            listOf(options.javaOutputDir),
+            listOf(options.kotlinOutputDir),
             addToEnvironment = true
         )
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/KotlinSymbolProcessingPlugin.kt
@@ -43,8 +43,10 @@ class KotlinSymbolProcessingCommandLineProcessor : CommandLineProcessor {
     private fun KspOptions.Builder.processOption(option: KspCliOption, value: String) = when (option) {
         KspCliOption.CONFIGURATION -> throw CliOptionProcessingException("${KspCliOption.CONFIGURATION.optionName} should be handled earlier")
         KspCliOption.PROCESSOR_CLASSPATH_OPTION -> processingClasspath += value.split(':').map{ File(it) }
-        KspCliOption.GENERATED_SOURCES_DIR_OPTION -> sourcesOutputDir = File(value)
-        KspCliOption.GENERATED_CLASSES_DIR_OPTION -> classesOutputDir = File(value)
+        KspCliOption.CLASS_OUTPUT_DIR_OPTION -> classOutputDir = File(value)
+        KspCliOption.JAVA_OUTPUT_DIR_OPTION -> javaOutputDir = File(value)
+        KspCliOption.KOTLIN_OUTPUT_DIR_OPTION -> kotlinOutputDir = File(value)
+        KspCliOption.RESOURCE_OUTPUT_DIR_OPTION -> resourceOutputDir = File(value)
     }
 }
 
@@ -71,17 +73,31 @@ enum class KspCliOption(
     @Deprecated("Do not use in CLI")
     CONFIGURATION("configuration", "<encoded>", "Encoded configuration"),
 
-    GENERATED_SOURCES_DIR_OPTION(
-        "sources",
-        "<sources>",
-        "Dir of generated sources",
+    CLASS_OUTPUT_DIR_OPTION(
+        "classOutputDir",
+        "<classOutputDir>",
+        "Dir of generated classes",
         false
     ),
 
-    GENERATED_CLASSES_DIR_OPTION(
-        "classes",
-        "<classes>",
-        "Dir of generated classes",
+    JAVA_OUTPUT_DIR_OPTION(
+        "javaOutputDir",
+        "<javaOutputDir>",
+        "Dir of generated Java sources",
+        false
+    ),
+
+    KOTLIN_OUTPUT_DIR_OPTION(
+        "kotlinOutputDir",
+        "<kotlinOutputDir>",
+        "Dir of generated Kotlin sources",
+        false
+    ),
+
+    RESOURCE_OUTPUT_DIR_OPTION(
+        "resourceOutputDir",
+        "<resourceOutputDir>",
+        "Dir of generated resources",
         false
     ),
 
@@ -98,8 +114,10 @@ class KspOptions(
     val compileClasspath: List<File>,
     val javaSourceRoots: List<File>,
 
-    val sourcesOutputDir: File,
-    val classesOutputDir: File,
+    val classOutputDir: File,
+    val javaOutputDir: File,
+    val kotlinOutputDir: File,
+    val resourceOutputDir: File,
 
     val processingClasspath: List<File>,
     val processors: List<String>,
@@ -111,8 +129,10 @@ class KspOptions(
         val compileClasspath: MutableList<File> = mutableListOf()
         val javaSourceRoots: MutableList<File> = mutableListOf()
 
-        var sourcesOutputDir: File? = null
-        var classesOutputDir: File? = null
+        var classOutputDir: File? = null
+        var javaOutputDir: File? = null
+        var kotlinOutputDir: File? = null
+        var resourceOutputDir: File? = null
 
         val processingClasspath: MutableList<File> = mutableListOf()
         val processors: MutableList<String> = mutableListOf()
@@ -122,7 +142,10 @@ class KspOptions(
         fun build(): KspOptions {
             return KspOptions(
                 projectBaseDir, compileClasspath, javaSourceRoots,
-                sourcesOutputDir!!, classesOutputDir!!,
+                classOutputDir!!,
+                javaOutputDir!!,
+                kotlinOutputDir!!,
+                resourceOutputDir!!,
                 processingClasspath, processors, processingOptions
             )
         }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/CodeGeneratorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/CodeGeneratorImpl.kt
@@ -9,14 +9,25 @@ import org.jetbrains.kotlin.ksp.processing.CodeGenerator
 import java.io.File
 import java.io.OutputStream
 
-class CodeGeneratorImpl(private val outputDir: File) : CodeGenerator {
+class CodeGeneratorImpl(
+    private val classDir: File,
+    private val javaDir: File,
+    private val kotlinDir: File,
+    private val resourcesDir: File
+) : CodeGenerator {
     private val fileMap = mutableMapOf<String, File>()
 
     // TODO: investigate if it works for Windows
     override fun createNewFile(packageName: String, fileName: String, extensionName: String): OutputStream {
         val packageDirs = if (packageName != "") "${packageName.split(".").joinToString("/")}/" else ""
         val extension = if (extensionName != "") ".${extensionName}" else ""
-        val path = "${outputDir.path}/$packageDirs$fileName${extension}"
+        val typeRoot = when (extensionName) {
+            "class" -> classDir
+            "java" -> javaDir
+            "kt" -> kotlinDir
+            else -> resourcesDir
+        }.path
+        val path = "$typeRoot/$packageDirs$fileName${extension}"
         if (fileMap[path] != null) return fileMap[path]!!.outputStream()
         val file = File(path)
         val parentFile = file.parentFile

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/AbstractKotlinKSPTest.kt
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/AbstractKotlinKSPTest.kt
@@ -34,8 +34,10 @@ abstract class AbstractKotlinKSPTest : CodegenTestCase() {
         val analysisExtension =
             KotlinSymbolProcessingExtension(KspOptions.Builder().apply {
                 javaSourceRoots.addAll(javaFiles.map { File(it.parent) }.distinct())
-                sourcesOutputDir = File("/tmp/kspTest")
-                classesOutputDir = File("/tmp/kspTest")
+                classOutputDir = File("/tmp/kspTest/classes/main")
+                javaOutputDir = File("/tmp/kspTest/src/main/java")
+                kotlinOutputDir = File("/tmp/kspTest/src/main/kotlin")
+                resourceOutputDir = File("/tmp/kspTest/src/main/resources")
             }.build(), testProcessor)
         val project = myEnvironment.project
         AnalysisHandlerExtension.registerExtension(project, analysisExtension)


### PR DESCRIPTION
Output directories of different file types are passed in command line so
as to allow customization seperately.