### PR TITLE
Resolve to aliases instead of underlying types

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
@@ -307,6 +307,7 @@ class ResolverImpl(
             when (psi) {
                 is KtClassOrObject -> KSClassDeclarationImpl.getCached(psi)
                 is PsiClass -> KSClassDeclarationJavaImpl.getCached(psi)
+                is KtTypeAlias -> KSTypeAliasImpl.getCached(psi)
                 else -> throw IllegalStateException()
             }
         } else {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeAliasProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeAliasProcessor.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.*
+
+open class TypeAliasProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    val typeCollector = TypeCollector()
+    val types = mutableListOf<KSType>()
+
+    override fun process(resolver: Resolver) {
+        val files = resolver.getAllFiles()
+
+        files.forEach {
+            it.accept(typeCollector, types)
+        }
+
+        val sortedTypes = types.sortedBy { it.declaration.simpleName.asString() }
+
+        for (i in sortedTypes) {
+            val r = mutableListOf<String>()
+            var a: KSType? = i
+            do {
+                r.add(a!!.declaration.simpleName.asString())
+                a = (a.declaration as? KSTypeAlias)?.type?.resolve()
+            } while (a != null)
+            results.add(r.joinToString(" = "))
+        }
+
+        for (i in types) {
+            for (j in types) {
+                assert(i == j)
+            }
+        }
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+}
+

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeComparisonProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeComparisonProcessor.kt
@@ -46,10 +46,10 @@ open class TypeComparisonProcessor : AbstractTestProcessor() {
 
 }
 
-class TypeCollector : KSTopDownVisitor<MutableSet<KSType>, Unit>() {
-    override fun defaultHandler(node: KSNode, data: MutableSet<KSType>) = Unit
+class TypeCollector : KSTopDownVisitor<MutableCollection<KSType>, Unit>() {
+    override fun defaultHandler(node: KSNode, data: MutableCollection<KSType>) = Unit
 
-    override fun visitTypeReference(typeReference: KSTypeReference, data: MutableSet<KSType>) {
+    override fun visitTypeReference(typeReference: KSTypeReference, data: MutableCollection<KSType>) {
         super.visitTypeReference(typeReference, data)
         typeReference.resolve()?.let { data.add(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -10,8 +10,8 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.replaceTypeArguments
-import org.jetbrains.kotlin.types.AbbreviatedType
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.getAbbreviation
 import org.jetbrains.kotlin.types.typeUtil.*
 
 class KSTypeImpl private constructor(
@@ -26,7 +26,7 @@ class KSTypeImpl private constructor(
             ksTypeArguments: List<KSTypeArgument>? = null,
             annotations: List<KSAnnotation> = listOf()
         ): KSTypeImpl {
-            val abbrev = (kotlinType as? AbbreviatedType)?.abbreviation
+            val abbrev = kotlinType.getAbbreviation()
             return cache.getOrPut(Pair(kotlinType, abbrev)) { KSTypeImpl(kotlinType, abbrev, ksTypeArguments, annotations) }
         }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -10,24 +10,30 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.replaceTypeArguments
+import org.jetbrains.kotlin.types.AbbreviatedType
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.*
 
 class KSTypeImpl private constructor(
     val kotlinType: KotlinType,
+    val abbreviation: KotlinType?,
     private val ksTypeArguments: List<KSTypeArgument>? = null,
     override val annotations: List<KSAnnotation> = listOf()
 ) : KSType {
-    companion object : KSObjectCache<KotlinType, KSTypeImpl>() {
+    companion object : KSObjectCache<Pair<KotlinType, KotlinType?>, KSTypeImpl>() {
         fun getCached(
             kotlinType: KotlinType,
             ksTypeArguments: List<KSTypeArgument>? = null,
             annotations: List<KSAnnotation> = listOf()
-        ) =
-            cache.getOrPut(kotlinType) { KSTypeImpl(kotlinType, ksTypeArguments, annotations) }
+        ): KSTypeImpl {
+            val abbrev = (kotlinType as? AbbreviatedType)?.abbreviation
+            return cache.getOrPut(Pair(kotlinType, abbrev)) { KSTypeImpl(kotlinType, abbrev, ksTypeArguments, annotations) }
+        }
     }
 
-    override val declaration: KSDeclaration = ResolverImpl.instance.findDeclaration(kotlinType)
+    override val declaration: KSDeclaration by lazy {
+        ResolverImpl.instance.findDeclaration(abbreviation ?: kotlinType)
+    }
 
     override val nullability: Nullability by lazy {
         when (kotlinType.nullability()) {
@@ -78,5 +84,5 @@ class KSTypeImpl private constructor(
 
     override fun hashCode(): Int = kotlinType.hashCode()
 
-    override fun toString(): String = kotlinType.toString()
+    override fun toString(): String = (abbreviation ?: kotlinType).toString()
 }

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -93,6 +93,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/resolveJavaType.kt");
     }
 
+    @TestMetadata("typeAlias.kt")
+    public void testTypeAlias() throws Exception {
+        runTest("plugins/ksp/testData/api/typeAlias.kt");
+    }
+
     @TestMetadata("typeComposure.kt")
     public void testTypeComposure() throws Exception {
         runTest("plugins/ksp/testData/api/typeComposure.kt");

--- a/plugins/ksp/testData/api/typeAlias.kt
+++ b/plugins/ksp/testData/api/typeAlias.kt
@@ -1,0 +1,16 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: TypeAliasProcessor
+// EXPECTED:
+// A = String
+// B = String
+// C = A = String
+// String
+// END
+
+typealias A = String
+typealias B = String
+typealias C = A
+val a: A = ""
+val b: B = ""
+val c: C = ""
+val d: String = ""


### PR DESCRIPTION
The original implementations skipped intermediate aliases and made them
transparent and non-observable.

Another solution is KSType.alias which points to the aliasing type and
is less intuitive.