### PR TITLE
add isAbstract util for properties and classes

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
@@ -95,6 +95,11 @@ fun KSClassDeclaration.getAllSuperTypes(): Sequence<KSType> {
         .distinct()
 }
 
+fun KSClassDeclaration.isAbstract() = this.classKind == ClassKind.INTERFACE || this.modifiers.contains(Modifier.ABSTRACT)
+
+fun KSPropertyDeclaration.isAbstract() = this.modifiers.contains(Modifier.ABSTRACT)
+        || (this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE
+
 fun KSDeclaration.isOpen() = !this.isLocal()
         && (this.modifiers.contains(Modifier.OVERRIDE)
         || this.modifiers.contains(Modifier.ABSTRACT)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DefaultFunctionProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DefaultFunctionProcessor.kt
@@ -6,8 +6,10 @@
 package org.jetbrains.kotlin.ksp.processor
 
 import org.jetbrains.kotlin.ksp.getDeclaredFunctions
+import org.jetbrains.kotlin.ksp.isAbstract
 import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.symbol.KSClassDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSPropertyDeclaration
 
 class DefaultFunctionProcessor : AbstractTestProcessor() {
 
@@ -22,6 +24,16 @@ class DefaultFunctionProcessor : AbstractTestProcessor() {
         result.add("${containsFun.simpleName.asString()}: ${containsFun.isAbstract}")
         val equalsFun = ktInterface.getAllFunctions().single { it.simpleName.asString() == "equals" }
         result.add("${equalsFun.simpleName.asString()}: ${equalsFun.isAbstract}")
+        val interfaceProperty = ktInterface.declarations.single { it.simpleName.asString() == "interfaceProperty" } as KSPropertyDeclaration
+        result.add("${interfaceProperty.simpleName.asString()}: ${interfaceProperty.isAbstract()}")
+        val abstractClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("B")) as KSClassDeclaration
+        result.add("${abstractClass.simpleName.asString()}: ${abstractClass.isAbstract()}")
+        val parameterVal = abstractClass.declarations.single { it.simpleName.asString() == "parameterVal" } as KSPropertyDeclaration
+        result.add("${parameterVal.simpleName.asString()}: ${parameterVal.isAbstract()}")
+        val abstractProperty = abstractClass.declarations.single { it.simpleName.asString() == "abstractProperty" } as KSPropertyDeclaration
+        result.add("${abstractProperty.simpleName.asString()}: ${abstractProperty.isAbstract()}")
+        val aProperty = abstractClass.declarations.single { it.simpleName.asString() == "a" } as KSPropertyDeclaration
+        result.add("${aProperty.simpleName.asString()}: ${aProperty.isAbstract()}")
     }
 
     private fun checkFunctions(classDec: KSClassDeclaration, funList: List<String>): List<String> {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -15,7 +15,6 @@ import org.jetbrains.kotlin.ksp.symbol.impl.*
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 import org.jetbrains.kotlin.resolve.OverridingUtil
-import org.jetbrains.kotlin.resolve.calls.inference.returnTypeOrNothing
 
 class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) : KSPropertyDeclaration {
     companion object : KSObjectCache<KtProperty, KSPropertyDeclarationImpl>() {

--- a/plugins/ksp/testData/api/interfaceWithDefault.kt
+++ b/plugins/ksp/testData/api/interfaceWithDefault.kt
@@ -7,6 +7,11 @@
 // bar: true
 // iterator: true
 // equals: false
+// interfaceProperty: true
+// B: true
+// parameterVal: false
+// abstractProperty: true
+// a: false
 // END
 // FILE: a.kt
 interface KTInterface: Sequence<String> {
@@ -18,6 +23,13 @@ interface KTInterface: Sequence<String> {
 
     fun emptyFun()
 
+    val interfaceProperty: String
+
+}
+
+abstract class B(val parameterVal: String) {
+    abstract val abstractProperty: String
+    val a: String = "str"
 }
 
 // FILE: C.java


### PR DESCRIPTION
This turned out to be trivia, since kotlin syntax prohibits implicit abstract declaration for properties.