### PR TITLE
Disable incremental compilation when ksp dependencies change

### DIFF
--- a/libraries/tools/kotlin-ksp-gradle/src/main/kotlin/org/jetbrains/kotlin/ksp/gradle/KspSubplugin.kt
+++ b/libraries/tools/kotlin-ksp-gradle/src/main/kotlin/org/jetbrains/kotlin/ksp/gradle/KspSubplugin.kt
@@ -87,6 +87,9 @@ class KspKotlinGradleSubplugin : KotlinGradleSubplugin<AbstractCompile> {
 
         kotlinCompile.dependsOn(kspConfiguration.buildDependencies)
 
+        if (kspConfiguration.buildDependencies.getDependencies(kotlinCompile).any { !it.state.upToDate })
+            kotlinCompile.setProperty("incremental", false)
+
         val options = mutableListOf<SubpluginOption>()
 
         options += FilesSubpluginOption("apclasspath", kspConfiguration)


### PR DESCRIPTION
This is a workaround to make sure processor changes trigger
re-processing. Ideally, incremental compilation only depends on the
output of processors rather than processors themselves. This is
impossible without change in upstream in current setting.