### PR TITLE
Disable incremental compilation when KSP is used.

### DIFF
--- a/libraries/tools/kotlin-ksp-gradle/src/main/kotlin/org/jetbrains/kotlin/ksp/gradle/KspSubplugin.kt
+++ b/libraries/tools/kotlin-ksp-gradle/src/main/kotlin/org/jetbrains/kotlin/ksp/gradle/KspSubplugin.kt
@@ -87,6 +87,8 @@ class KspKotlinGradleSubplugin : KotlinGradleSubplugin<AbstractCompile> {
 
         kotlinCompile.dependsOn(kspConfiguration.buildDependencies)
 
+        kotlinCompile.setProperty("incremental", false)
+
         val options = mutableListOf<SubpluginOption>()
 
         options += FilesSubpluginOption("apclasspath", kspConfiguration)


### PR DESCRIPTION
This is a workaround to make sure that processors re-run with proper
inputs when there are changes to processors themselves or their inputs.
Currently KSP lives within the same task with the main compilation. When
it is triggered and what inputs it receives are subject to the logic of
incremental compilation, which is different from the requirement of KSP.