### PR TITLE
Ksp logger

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/processing/KSPLogger.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/processing/KSPLogger.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processing
+
+import org.jetbrains.kotlin.ksp.symbol.KSNode
+
+interface KSPLogger {
+
+    fun logging(message: String, symbol: KSNode)
+    fun info(message: String, symbol: KSNode)
+    fun warn(message: String, symbol: KSNode)
+    fun error(message: String, symbol: KSNode)
+
+    fun exception(e: Throwable)
+}

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/processing/SymbolProcessor.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/processing/SymbolProcessor.kt
@@ -16,7 +16,7 @@ interface SymbolProcessor {
      * @param kotlinVersion language version of compilation environment.
      * @param codeGenerator creates managed files.
      */
-    fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator)
+    fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger)
 
     /**
      * Called by Kotlin Symbol Processing to run the processing task.

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/Location.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/Location.kt
@@ -5,11 +5,8 @@
 
 package org.jetbrains.kotlin.ksp.symbol
 
-/**
- * Base class of every visitable program elements.
- */
-interface KSNode {
-    val origin: Origin
-    val location: Location
-    fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R
-}
+sealed class Location
+
+data class FileLocation(val filePath: String, val lineNumber: Int) : Location()
+
+object NonExistLocation : Location()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/MessageCollectorBasedKSPLogger.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/MessageCollectorBasedKSPLogger.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processing.impl
+
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ksp.processing.KSPLogger
+import org.jetbrains.kotlin.ksp.symbol.FileLocation
+import org.jetbrains.kotlin.ksp.symbol.KSNode
+import org.jetbrains.kotlin.ksp.symbol.NonExistLocation
+import java.io.PrintWriter
+import java.io.StringWriter
+
+class MessageCollectorBasedKSPLogger(private val messageCollector: MessageCollector) : KSPLogger {
+
+    companion object {
+        const val PREFIX = "[ksp] "
+    }
+
+    private fun convertMessage(message: String, symbol: KSNode): String =
+        when (val location = symbol.location) {
+            is FileLocation -> "$PREFIX${location.filePath}:${location.lineNumber}: $message"
+            is NonExistLocation -> "$PREFIX$message"
+        }
+
+    override fun logging(message: String, symbol: KSNode) {
+        messageCollector.report(CompilerMessageSeverity.LOGGING, convertMessage(message, symbol))
+    }
+
+    override fun info(message: String, symbol: KSNode) {
+        messageCollector.report(CompilerMessageSeverity.INFO, convertMessage(message, symbol))
+    }
+
+    override fun warn(message: String, symbol: KSNode) {
+        messageCollector.report(CompilerMessageSeverity.WARNING, convertMessage(message, symbol))
+    }
+
+    override fun error(message: String, symbol: KSNode) {
+        messageCollector.report(CompilerMessageSeverity.ERROR, convertMessage(message, symbol))
+    }
+
+    override fun exception(e: Throwable) {
+        val writer = StringWriter()
+        e.printStackTrace(PrintWriter(writer))
+        messageCollector.report(CompilerMessageSeverity.EXCEPTION, writer.toString())
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.ksp.processing.impl
 
+import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.kotlin.container.ComponentProvider
@@ -52,9 +53,11 @@ class ResolverImpl(
     files: Collection<KtFile>,
     javaFiles: Collection<PsiJavaFile>,
     val bindingTrace: BindingTrace,
+    val project: Project,
     componentProvider: ComponentProvider
 ) : Resolver {
     val ksFiles: List<KSFile>
+    val psiDocumentManager = PsiDocumentManager.getInstance(project)
     val javaActualAnnotationArgumentExtractor = JavaActualAnnotationArgumentExtractor()
     private val nameToKSMap: MutableMap<KSName, KSClassDeclaration>
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/AbstractTestProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/AbstractTestProcessor.kt
@@ -6,11 +6,12 @@
 package org.jetbrains.kotlin.ksp.processor
 
 import org.jetbrains.kotlin.ksp.processing.CodeGenerator
+import org.jetbrains.kotlin.ksp.processing.KSPLogger
 import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.processing.SymbolProcessor
 
 abstract class AbstractTestProcessor : SymbolProcessor {
-    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator) {
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
     }
 
     override fun finish() {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -30,6 +30,8 @@ class KSAnnotationDescriptorImpl private constructor(val descriptor: AnnotationD
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val annotationType: KSTypeReference by lazy {
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -30,6 +30,8 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
@@ -7,9 +7,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
 import org.jetbrains.kotlin.descriptors.ClassifierDescriptorWithTypeParameters
-import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
-import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
-import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeProjection
@@ -33,6 +31,8 @@ class KSClassifierReferenceDescriptorImpl private constructor(val descriptor: Cl
     }
 
     override val origin = Origin.CLASS
+
+    override val location: Location = NonExistLocation
 
     override val qualifier: KSClassifierReference? by lazy {
         val outerDescriptor = descriptor.containingDeclaration as? ClassifierDescriptor ?: return@lazy null

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -27,6 +27,8 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val containingFile: KSFile? = null
 
     override val parentDeclaration: KSDeclaration? by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -23,6 +23,8 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Va
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
@@ -18,6 +18,8 @@ class KSPropertyGetterDescriptorImpl private constructor(val descriptor: Propert
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
@@ -18,6 +18,8 @@ class KSPropertySetterDescriptorImpl private constructor(val descriptor: Propert
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
@@ -17,6 +17,8 @@ class KSTypeArgumentDescriptorImpl private constructor(val descriptor: TypeProje
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val type: KSTypeReference by lazy {
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
@@ -22,6 +22,8 @@ class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypePara
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val bounds: List<KSTypeReference> by lazy {
         descriptor.upperBounds.map { KSTypeReferenceDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
@@ -21,6 +21,8 @@ class KSTypeReferenceDescriptorImpl private constructor(val kotlinType: KotlinTy
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val element: KSReferenceElement by lazy {
         when {
             kotlinType.constructor.declarationDescriptor is ClassDescriptor -> KSClassifierReferenceDescriptorImpl.getCached(kotlinType)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSVariableParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSVariableParameterDescriptorImpl.kt
@@ -19,6 +19,8 @@ class KSVariableParameterDescriptorImpl private constructor(val descriptor: Valu
 
     override val origin = Origin.CLASS
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> by lazy {
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.getAbsentDefaultArguments
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
 class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnotation {
     companion object : KSObjectCache<PsiAnnotation, KSAnnotationJavaImpl>() {
@@ -22,6 +23,10 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
 
     override val annotationType: KSTypeReference by lazy {
         KSTypeReferenceLiteJavaImpl.getCached(

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -29,6 +29,10 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) : KSClas
 
     override val origin = Origin.JAVA
 
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
@@ -10,8 +10,10 @@ import com.intellij.psi.PsiJavaCodeReferenceElement
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
+import org.jetbrains.kotlin.ksp.symbol.Location
 import org.jetbrains.kotlin.ksp.symbol.Origin
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
 class KSClassifierReferenceJavaImpl private constructor(val psi: PsiClassType) : KSClassifierReference {
     companion object : KSObjectCache<PsiClassType, KSClassifierReferenceJavaImpl>() {
@@ -19,6 +21,10 @@ class KSClassifierReferenceJavaImpl private constructor(val psi: PsiClassType) :
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location by lazy {
+        TODO()
+    }
 
     override val qualifier: KSClassifierReference? by lazy {
         val qualifierReference = (psi as? PsiClassReferenceType)?.reference?.qualifier as? PsiJavaCodeReferenceElement ?: return@lazy null

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
@@ -8,10 +8,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiJavaCodeReferenceElement
 import com.intellij.psi.impl.source.PsiClassReferenceType
-import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
-import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
-import org.jetbrains.kotlin.ksp.symbol.Location
-import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
@@ -23,7 +20,7 @@ class KSClassifierReferenceJavaImpl private constructor(val psi: PsiClassType) :
     override val origin = Origin.JAVA
 
     override val location: Location by lazy {
-        TODO()
+        (psi as? PsiJavaCodeReferenceElement)?.toLocation() ?: NonExistLocation
     }
 
     override val qualifier: KSClassifierReference? by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFileJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFileJavaImpl.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiJavaFile
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
 class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile {
     companion object : KSObjectCache<PsiJavaFile, KSFileJavaImpl>() {
@@ -16,6 +17,10 @@ class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile {
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> = emptyList()
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSFunctionDeclarationImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
 class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KSFunctionDeclaration {
@@ -27,6 +28,10 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KS
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
 class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSPropertyDeclaration {
@@ -24,6 +25,10 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSP
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
@@ -18,6 +18,10 @@ class KSTypeArgumentJavaImpl private constructor(val psi: PsiType) : KSTypeArgum
 
     override val origin = Origin.JAVA
 
+    override val location: Location by lazy {
+        TODO()
+    }
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
@@ -7,9 +7,11 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiWildcardType
+import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
 class KSTypeArgumentJavaImpl private constructor(val psi: PsiType) : KSTypeArgumentImpl() {
     companion object : KSObjectCache<PsiType, KSTypeArgumentJavaImpl>() {
@@ -19,7 +21,7 @@ class KSTypeArgumentJavaImpl private constructor(val psi: PsiType) : KSTypeArgum
     override val origin = Origin.JAVA
 
     override val location: Location by lazy {
-        TODO()
+        (psi as? PsiClassReferenceType)?.reference?.toLocation() ?: NonExistLocation
     }
 
     override val annotations: List<KSAnnotation> by lazy {
@@ -28,15 +30,7 @@ class KSTypeArgumentJavaImpl private constructor(val psi: PsiType) : KSTypeArgum
 
     // Could be unbounded, need to model unbdouned type argument.
     override val type: KSTypeReference? by lazy {
-        if (psi is PsiWildcardType) {
-            if (psi.bound != null) {
-                KSTypeReferenceJavaImpl.getCached(psi.bound!!)
-            } else {
-                null
-            }
-        } else {
-            KSTypeReferenceJavaImpl.getCached(psi)
-        }
+        KSTypeReferenceJavaImpl.getCached(psi)
     }
 
     override val variance: Variance by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
 class KSTypeParameterJavaImpl private constructor(val psi: PsiTypeParameter) : KSTypeParameter {
     companion object : KSObjectCache<PsiTypeParameter, KSTypeParameterJavaImpl>() {
@@ -18,6 +19,10 @@ class KSTypeParameterJavaImpl private constructor(val psi: PsiTypeParameter) : K
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -20,6 +20,10 @@ class KSTypeReferenceJavaImpl private constructor(val psi: PsiType) : KSTypeRefe
 
     override val origin = Origin.JAVA
 
+    override val location: Location by lazy {
+        TODO()
+    }
+
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -6,10 +6,12 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.java
 
 import com.intellij.psi.*
+import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSClassifierReferenceDescriptorImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.Variance
 
@@ -21,7 +23,7 @@ class KSTypeReferenceJavaImpl private constructor(val psi: PsiType) : KSTypeRefe
     override val origin = Origin.JAVA
 
     override val location: Location by lazy {
-        TODO()
+        (psi as? PsiClassReferenceType)?.reference?.toLocation() ?: NonExistLocation
     }
 
     override val annotations: List<KSAnnotation> by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
@@ -15,6 +15,8 @@ class KSTypeReferenceLiteJavaImpl private constructor(val type: KSType) : KSType
 
     override val origin = Origin.JAVA
 
+    override val location: Location = NonExistLocation
+
     override val element: KSReferenceElement? = null
 
     override val annotations: List<KSAnnotation> = emptyList()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSValueArgumentJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSValueArgumentJavaImpl.kt
@@ -5,9 +5,7 @@
 
 package org.jetbrains.kotlin.ksp.symbol.impl.java
 
-import org.jetbrains.kotlin.ksp.symbol.KSAnnotation
-import org.jetbrains.kotlin.ksp.symbol.KSName
-import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSValueArgumentImpl
 
@@ -17,6 +15,8 @@ class KSValueArgumentJavaImpl private constructor(override val name: KSName?, ov
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location = NonExistLocation
 
     override val isSpread: Boolean = false
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSVariableParameterJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSVariableParameterJavaImpl.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiParameter
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
 class KSVariableParameterJavaImpl private constructor(val psi: PsiParameter) : KSVariableParameter {
     companion object : KSObjectCache<PsiParameter, KSVariableParameterJavaImpl>() {
@@ -16,6 +17,10 @@ class KSVariableParameterJavaImpl private constructor(val psi: PsiParameter) : K
     }
 
     override val origin = Origin.JAVA
+
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> by lazy {
         psi.annotations.map { KSAnnotationJavaImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.createKSValueArguments
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 
 class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEntry) : KSAnnotation {
@@ -18,6 +19,10 @@ class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEn
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktAnnotationEntry.toLocation()
+    }
 
     override val annotationType: KSTypeReference by lazy {
         KSTypeReferenceImpl.getCached(ktAnnotationEntry.typeReference!!)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSCallableReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSCallableReferenceImpl.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtFunctionType
 
 class KSCallableReferenceImpl private constructor(val ktFunctionType: KtFunctionType) : KSCallableReference {
@@ -15,6 +16,10 @@ class KSCallableReferenceImpl private constructor(val ktFunctionType: KtFunction
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktFunctionType.toLocation()
+    }
 
     override val typeArguments: List<KSTypeArgument> by lazy {
         ktFunctionType.typeArgumentsAsTypes.map { KSTypeArgumentLiteImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.*
-import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSFunctionDeclarationDescriptorImpl
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
@@ -24,6 +23,10 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktClassOrObject.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> by lazy {
         ktClassOrObject.annotationEntries.map { KSAnnotationImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
@@ -7,8 +7,10 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.KSClassifierReference
 import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
+import org.jetbrains.kotlin.ksp.symbol.Location
 import org.jetbrains.kotlin.ksp.symbol.Origin
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.*
 
 class KSClassifierReferenceImpl private constructor(val ktUserType: KtUserType) : KSClassifierReference {
@@ -17,6 +19,10 @@ class KSClassifierReferenceImpl private constructor(val ktUserType: KtUserType) 
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktUserType.toLocation()
+    }
 
     override val typeArguments: List<KSTypeArgument> by lazy {
         ktUserType.typeArguments.map { KSTypeArgumentKtImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
@@ -5,10 +5,7 @@
 
 package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
-import org.jetbrains.kotlin.ksp.symbol.KSDynamicReference
-import org.jetbrains.kotlin.ksp.symbol.KSTypeArgument
-import org.jetbrains.kotlin.ksp.symbol.KSVisitor
-import org.jetbrains.kotlin.ksp.symbol.Origin
+import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtUserType
 
@@ -18,6 +15,10 @@ class KSDynamicReferenceImpl private constructor() : KSDynamicReference {
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        NonExistLocation
+    }
 
     override val typeArguments: List<KSTypeArgument> = listOf<KSTypeArgument>()
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFileImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFileImpl.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.getKSDeclarations
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtFile
 
 class KSFileImpl private constructor(val file: KtFile) : KSFile {
@@ -16,6 +17,10 @@ class KSFileImpl private constructor(val file: KtFile) : KSFile {
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        file.toLocation()
+    }
 
     override val packageName: KSName by lazy {
         KSNameImpl.getCached(file.packageFqName.toString())

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -25,6 +25,10 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
 
     override val origin = Origin.KOTLIN
 
+    override val location: Location by lazy {
+        ktFunction.toLocation()
+    }
+
     override val annotations: List<KSAnnotation> by lazy {
         ktFunction.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -23,6 +23,10 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
 
     override val origin = Origin.KOTLIN
 
+    override val location: Location by lazy {
+        ktProperty.toLocation()
+    }
+
     override val annotations: List<KSAnnotation> by lazy {
         ktProperty.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtStubbedPsiUtil
@@ -24,6 +25,10 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktParameter.toLocation()
+    }
 
     override val extensionReceiver: KSTypeReference? = null
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 
 class KSPropertyGetterImpl private constructor(val ktPropertyGetter: KtPropertyAccessor) : KSPropertyGetter {
@@ -19,6 +20,10 @@ class KSPropertyGetterImpl private constructor(val ktPropertyGetter: KtPropertyA
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktPropertyGetter.toLocation()
+    }
 
     override val returnType: KSTypeReference? by lazy {
         val property = ktPropertyGetter.property

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 
 class KSPropertySetterImpl private constructor(val ktPropertySetter: KtPropertyAccessor) : KSPropertySetter {
@@ -16,6 +17,10 @@ class KSPropertySetterImpl private constructor(val ktPropertySetter: KtPropertyA
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktPropertySetter.toLocation()
+    }
 
     override val parameter: KSVariableParameter by lazy {
         ktPropertySetter.parameterList?.parameters?.singleOrNull()?.let { KSVariableParameterImpl.getCached(it) } ?: throw IllegalStateException()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.*
 
 class KSTypeAliasImpl private constructor(val ktTypeAlias: KtTypeAlias) : KSTypeAlias {
@@ -17,6 +18,10 @@ class KSTypeAliasImpl private constructor(val ktTypeAlias: KtTypeAlias) : KSType
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktTypeAlias.toLocation()
+    }
 
     override val containingFile: KSFile by lazy {
         KSFileImpl.getCached(ktTypeAlias.containingKtFile)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentImpl.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtProjectionKind
 import org.jetbrains.kotlin.psi.KtTypeProjection
 
@@ -33,6 +34,10 @@ class KSTypeArgumentKtImpl private constructor(val ktTypeArgument: KtTypeProject
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktTypeArgument.toLocation()
+    }
 
     override val variance: Variance by lazy {
         when (ktTypeArgument.projectionKind) {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentLiteImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeArgumentLiteImpl.kt
@@ -22,5 +22,7 @@ class KSTypeArgumentLiteImpl private constructor(override val type: KSTypeRefere
 
     override val origin = Origin.KOTLIN
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> = type.annotations
 }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
@@ -18,6 +19,10 @@ class KSTypeParameterImpl private constructor(val ktTypeParameter: KtTypeParamet
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktTypeParameter.toLocation()
+    }
 
     override val name: KSName by lazy {
         KSNameImpl.getCached(ktTypeParameter.name!!)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceDeferredImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceDeferredImpl.kt
@@ -15,6 +15,8 @@ class KSTypeReferenceDeferredImpl private constructor(private val resolver: () -
 
     override val origin = Origin.KOTLIN
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> = emptyList()
 
     override val element: KSReferenceElement? = null

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.*
 import java.lang.IllegalStateException
 
@@ -18,6 +19,10 @@ class KSTypeReferenceImpl private constructor(val ktTypeReference: KtTypeReferen
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktTypeReference.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> by lazy {
         ktTypeReference.annotationEntries.map { KSAnnotationImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSValueArgumentImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSValueArgumentImpl.kt
@@ -15,6 +15,8 @@ class KSValueArgumentLiteImpl private constructor(override val name: KSName, ove
 
     override val origin = Origin.KOTLIN
 
+    override val location: Location = NonExistLocation
+
     override val annotations: List<KSAnnotation> = emptyList()
 
     override val isSpread: Boolean = false

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSVariableParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSVariableParameterImpl.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.ksp.symbol.impl.kotlin
 
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.lexer.KtTokens.CROSSINLINE_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.NOINLINE_KEYWORD
 import org.jetbrains.kotlin.psi.KtParameter
@@ -17,6 +18,10 @@ class KSVariableParameterImpl private constructor(val ktParameter: KtParameter) 
     }
 
     override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktParameter.toLocation()
+    }
 
     override val annotations: List<KSAnnotation> by lazy {
         ktParameter.annotationEntries.map { KSAnnotationImpl.getCached(it) }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.descriptors.MemberDescriptor
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSFunctionDeclarationDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
@@ -165,6 +166,12 @@ fun PsiElement.findParentDeclaration(): KSDeclaration? {
         is PsiMethod -> KSFunctionDeclarationJavaImpl.getCached(parent)
         else -> null
     }
+}
+
+fun PsiElement.toLocation(): Location {
+    val file = this.containingFile
+    val document = ResolverImpl.instance.psiDocumentManager.getDocument(file) ?: return NonExistLocation
+    return FileLocation(file.virtualFile.path, document.getLineNumber(document.getLineStartOffset(this.textOffset)))
 }
 
 // TODO: handle local functions/classes correctly

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.StarProjectionImpl
 import org.jetbrains.kotlin.types.TypeProjectionImpl
@@ -171,7 +172,7 @@ fun PsiElement.findParentDeclaration(): KSDeclaration? {
 fun PsiElement.toLocation(): Location {
     val file = this.containingFile
     val document = ResolverImpl.instance.psiDocumentManager.getDocument(file) ?: return NonExistLocation
-    return FileLocation(file.virtualFile.path, document.getLineNumber(document.getLineStartOffset(this.textOffset)))
+    return FileLocation(file.virtualFile.path, document.getLineNumber(this.textOffset) + 1)
 }
 
 // TODO: handle local functions/classes correctly

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/AbstractKotlinKSPTest.kt
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/AbstractKotlinKSPTest.kt
@@ -6,10 +6,13 @@
 package org.jetbrains.kotlin.ksp.test
 
 import junit.framework.TestCase
+import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
+import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.codegen.CodegenTestCase
 import org.jetbrains.kotlin.codegen.GenerationUtils
 import org.jetbrains.kotlin.ksp.KotlinSymbolProcessingExtension
 import org.jetbrains.kotlin.ksp.KspOptions
+import org.jetbrains.kotlin.ksp.processing.impl.MessageCollectorBasedKSPLogger
 import org.jetbrains.kotlin.ksp.processor.AbstractTestProcessor
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import org.jetbrains.kotlin.test.ConfigurationKind
@@ -31,6 +34,7 @@ abstract class AbstractKotlinKSPTest : CodegenTestCase() {
             .substringAfter(TEST_PROCESSOR)
             .trim()
         val testProcessor = Class.forName("org.jetbrains.kotlin.ksp.processor.$testProcessorName").newInstance() as AbstractTestProcessor
+        val logger = MessageCollectorBasedKSPLogger(PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, false))
         val analysisExtension =
             KotlinSymbolProcessingExtension(KspOptions.Builder().apply {
                 javaSourceRoots.addAll(javaFiles.map { File(it.parent) }.distinct())
@@ -38,7 +42,7 @@ abstract class AbstractKotlinKSPTest : CodegenTestCase() {
                 javaOutputDir = File("/tmp/kspTest/src/main/java")
                 kotlinOutputDir = File("/tmp/kspTest/src/main/kotlin")
                 resourceOutputDir = File("/tmp/kspTest/src/main/resources")
-            }.build(), testProcessor)
+            }.build(), logger, testProcessor)
         val project = myEnvironment.project
         AnalysisHandlerExtension.registerExtension(project, analysisExtension)
         loadMultiFiles(files)


### PR DESCRIPTION
Tested with playground project.

Currently logging levels higher than LOGGING are intercepted by kotlin compile daemon, therefore if running with gradle plugin only Logger.logging with be available in output.