### PR TITLE
fix logic to find function declaration implementation, only declared members should be possible to be converted

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -7,12 +7,10 @@ package org.jetbrains.kotlin.ksp.symbol.impl
 
 import com.intellij.lang.jvm.JvmModifier
 import com.intellij.psi.*
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.MemberDescriptor
-import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.ClassKind
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSFunctionDeclarationDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.java.KSClassDeclarationJavaImpl
@@ -232,6 +230,7 @@ internal fun KotlinType.replaceTypeArguments(newArguments: List<KSTypeArgument>)
     })
 
 internal fun FunctionDescriptor.toKSFunctionDeclaration(): KSFunctionDeclaration {
+    if (this.kind != CallableMemberDescriptor.Kind.DECLARATION) return KSFunctionDeclarationDescriptorImpl.getCached(this)
     val psi = this.findPsi() ?: return KSFunctionDeclarationDescriptorImpl.getCached(this)
     return when (psi) {
         is KtFunction -> KSFunctionDeclarationImpl.getCached(psi)

--- a/plugins/ksp/testData/api/allFunctions.kt
+++ b/plugins/ksp/testData/api/allFunctions.kt
@@ -5,11 +5,16 @@
 // bar(): kotlin.Boolean
 // baz(kotlin.String,kotlin.String(hasDefault),kotlin.String(hasDefault)): kotlin.Boolean
 // class: C
+// class: Data
+// component1(): kotlin.String
 // contains(kotlin.Number): kotlin.Boolean
 // containsAll(kotlin.collections.Collection): kotlin.Boolean
+// copy(kotlin.String(hasDefault)): Data
+// equals(kotlin.Any): kotlin.Boolean
 // equals(kotlin.Any): kotlin.Boolean
 // equals(kotlin.Any): kotlin.Boolean
 // get(kotlin.Int): kotlin.Number
+// hashCode(): kotlin.Int
 // hashCode(): kotlin.Int
 // hashCode(): kotlin.Int
 // indexOf(kotlin.Number): kotlin.Int
@@ -26,6 +31,7 @@
 // subList(kotlin.Int,kotlin.Int): kotlin.collections.List
 // toString(): kotlin.String
 // toString(): kotlin.String
+// toString(): kotlin.String
 // END
 // FILE: a.kt
 abstract class Foo : C(), List<out Number> {
@@ -38,6 +44,12 @@ abstract class Foo : C(), List<out Number> {
     }
 
     fun baz(input: String, input2: String? = null, input3: String = ""): Boolean {
+        return false
+    }
+}
+
+data class Data(val a: String) {
+    override fun equals(other: Any?): Boolean {
         return false
     }
 }


### PR DESCRIPTION
Previously for synthetic members like members from data class, findPsi() will return their parent.