### PR TITLE
Add a reified KSClassDeclaration helper to Resolver

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
@@ -5,7 +5,22 @@
 
 package org.jetbrains.kotlin.ksp
 
+import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.symbol.*
+
+/**
+ * Try to resolve the [KSClassDeclaration] for a class [T], using its fully qualified name.
+ *
+ * @param T The class to resolve a [KSClassDeclaration] for.
+ * @return Resolved [KSClassDeclaration] if found, `null` otherwise.
+ *
+ * @see [Resolver.getClassDeclarationByName]
+ */
+inline fun <reified T> Resolver.getClassDeclarationByName(): KSClassDeclaration? {
+    return T::class.qualifiedName?.let { fqcn ->
+        getClassDeclarationByName(getKSNameFromString(fqcn))
+    }
+}
 
 /**
  * Get functions directly declared inside the class declaration.

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.symbol.*
 
 /**
- * Try to resolve the [KSClassDeclaration] for a class [T], using its fully qualified name.
+ * Try to resolve the [KSClassDeclaration] for a class using its fully qualified name.
  *
  * @param T The class to resolve a [KSClassDeclaration] for.
  * @return Resolved [KSClassDeclaration] if found, `null` otherwise.


### PR DESCRIPTION
Retrieiving the KSClassDeclaration for a KClass is a common operation,
which is currently quite verbose. This adds an extension on top of
Resolver for a more user-friendly API.