### PR TITLE
fix annotation arugment list for annotations with no use-site arguments.

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -24,10 +24,7 @@ class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEn
     }
 
     override val arguments: List<KSValueArgument> by lazy {
-        if (ktAnnotationEntry.valueArguments.isEmpty())
-            listOf()
-        else
-            resolved?.createKSValueArguments() ?: listOf()
+        resolved?.createKSValueArguments() ?: listOf()
     }
 
     override val shortName: KSName by lazy {


### PR DESCRIPTION
Previous early termination optimization for annotation arguments is no longer valid after the latest changes for default values, and should be removed.