### PR TITLE
Resolve user types via descriptor of parent declaration.

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
@@ -294,7 +294,7 @@ class ResolverImpl(
         }
     }
 
-    // TODO: local scope
+    // Finds closest non-local scope.
     fun KtElement.findLexicalScope(): LexicalScope {
         return containingNonLocalDeclaration()?.let {
             resolveSession.declarationScopeProvider.getResolutionScopeForDeclaration(it)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
@@ -18,11 +18,7 @@ import org.jetbrains.kotlin.ksp.processing.KSBuiltIns
 import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.*
-import org.jetbrains.kotlin.ksp.symbol.impl.java.KSClassDeclarationJavaImpl
-import org.jetbrains.kotlin.ksp.symbol.impl.java.KSFileJavaImpl
-import org.jetbrains.kotlin.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
-import org.jetbrains.kotlin.ksp.symbol.impl.java.KSPropertyDeclarationJavaImpl
-import org.jetbrains.kotlin.ksp.symbol.impl.java.KSTypeReferenceJavaImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.java.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.*
 import org.jetbrains.kotlin.load.java.components.TypeUsage
 import org.jetbrains.kotlin.load.java.lazy.JavaResolverComponents
@@ -32,7 +28,10 @@ import org.jetbrains.kotlin.load.java.lazy.TypeParameterResolver
 import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaTypeParameterDescriptor
 import org.jetbrains.kotlin.load.java.lazy.types.JavaTypeResolver
 import org.jetbrains.kotlin.load.java.lazy.types.toAttributes
-import org.jetbrains.kotlin.load.java.structure.impl.*
+import org.jetbrains.kotlin.load.java.structure.impl.JavaClassImpl
+import org.jetbrains.kotlin.load.java.structure.impl.JavaMethodImpl
+import org.jetbrains.kotlin.load.java.structure.impl.JavaTypeImpl
+import org.jetbrains.kotlin.load.java.structure.impl.JavaTypeParameterImpl
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.*
@@ -46,9 +45,9 @@ import org.jetbrains.kotlin.resolve.multiplatform.findActuals
 import org.jetbrains.kotlin.resolve.multiplatform.findExpects
 import org.jetbrains.kotlin.resolve.scopes.LexicalScope
 import org.jetbrains.kotlin.resolve.scopes.getDescriptorsFiltered
-import org.jetbrains.kotlin.resolve.scopes.utils.memberScopeAsImportingScope
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.replaceArgumentsWithStarProjections
+import org.jetbrains.kotlin.util.containingNonLocalDeclaration
 
 class ResolverImpl(
     val module: ModuleDescriptor,
@@ -231,47 +230,18 @@ class ResolverImpl(
         return javaTypeResolver.transformJavaType(javaType, TypeUsage.COMMON.toAttributes())
     }
 
-    private val DeclarationDescriptor.containingScope: LexicalScope
-        get() {
-            findPsi()?.let { return resolveSession.declarationScopeProvider.getResolutionScopeForDeclaration(it) }
-            val containingDescriptor = this.containingDeclaration
-            return when (containingDescriptor) {
-                is ClassDescriptorWithResolutionScopes -> containingDescriptor.scopeForInitializerResolution
-                is PackageFragmentDescriptor -> LexicalScope.Base(containingDescriptor.getMemberScope().memberScopeAsImportingScope(), this)
-                else -> containingDeclaration?.containingScope ?: throw IllegalStateException()
-            }
-        }
-
     fun resolveUserType(type: KSTypeReference): KSType? {
         when (type) {
             is KSTypeReferenceImpl -> {
                 val typeReference = type.ktTypeReference
-                if (KtStubbedPsiUtil.getContainingDeclaration(typeReference)?.let { KtPsiUtil.isLocal(it) } == true) {
-                    resolveContainingFunctionBody(typeReference)
-                    bindingTrace.bindingContext.get(BindingContext.TYPE, typeReference)
-                        ?.let { return KSTypeImpl.getCached(it, type.element.typeArguments, type.annotations) } ?: return null
-                }
-                val scope: LexicalScope?
-                var lowerDeclaration = KtStubbedPsiUtil.getPsiOrStubParent(
-                    typeReference,
-                    KtDeclaration::class.java, false
-                )
-                var parentDeclaration =
-                    lowerDeclaration?.let { KtStubbedPsiUtil.getContainingDeclaration(lowerDeclaration as KtDeclaration) }
-                while (parentDeclaration != null && parentDeclaration !is KtClassOrObject) {
-                    lowerDeclaration = parentDeclaration
-                    parentDeclaration = KtStubbedPsiUtil.getContainingDeclaration(parentDeclaration)
-                }
-                if (lowerDeclaration == null) {
-                    scope = resolveSession.fileScopeProvider.getFileResolutionScope(typeReference.containingKtFile)
-                } else {
-                    if (parentDeclaration == null || parentDeclaration is KtFile) {
-                        scope = resolveSession.declarationScopeProvider.getResolutionScopeForDeclaration(lowerDeclaration)
-                    } else {
-                        scope = resolveDeclaration(lowerDeclaration)?.containingScope
+                KtStubbedPsiUtil.getContainingDeclaration(typeReference)?.let {
+                    resolveDeclaration(it)
+                    bindingTrace.bindingContext.get(BindingContext.TYPE, typeReference)?.let {
+                        return KSTypeImpl.getCached(it, type.element.typeArguments, type.annotations)
                     }
                 }
-                return resolveSession.typeResolver.resolveType(scope!!, typeReference, bindingTrace, false).let {
+                val scope = resolveSession.fileScopeProvider.getFileResolutionScope(typeReference.containingKtFile)
+                return resolveSession.typeResolver.resolveType(scope, typeReference, bindingTrace, false).let {
                     KSTypeImpl.getCached(it, type.element.typeArguments, type.annotations)
                 }
             }
@@ -325,11 +295,10 @@ class ResolverImpl(
     }
 
     // TODO: local scope
-    fun KtElement.findLexicalScope(): LexicalScope? {
-        val containingDeclaration = KtStubbedPsiUtil.getContainingDeclaration(this)
-            ?: return resolveSession.fileScopeProvider.getFileResolutionScope(this.containingKtFile)
-
-        return containingDeclaration.let { resolveDeclaration(it)?.containingScope }
+    fun KtElement.findLexicalScope(): LexicalScope {
+        return containingNonLocalDeclaration()?.let {
+            resolveSession.declarationScopeProvider.getResolutionScopeForDeclaration(it)
+        } ?: resolveSession.fileScopeProvider.getFileResolutionScope(this.containingKtFile)
     }
 
     fun resolveAnnotationEntry(ktAnnotationEntry: KtAnnotationEntry): AnnotationDescriptor? {
@@ -339,7 +308,7 @@ class ResolverImpl(
             resolveContainingFunctionBody(containingDeclaration)
             bindingTrace.get(BindingContext.ANNOTATION, ktAnnotationEntry)
         } else {
-            ktAnnotationEntry.findLexicalScope()?.let { scope ->
+            ktAnnotationEntry.findLexicalScope().let { scope ->
                 annotationResolver.resolveAnnotationsWithArguments(scope, listOf(ktAnnotationEntry), bindingTrace)
                 bindingTrace.get(BindingContext.ANNOTATION, ktAnnotationEntry)
             }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeParameterReferenceProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeParameterReferenceProcessor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
+import org.jetbrains.kotlin.ksp.visitor.KSTopDownVisitor
+
+open class TypeParameterReferenceProcessor: AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    val collector = ReferenceCollector()
+    val references = mutableSetOf<KSTypeReference>()
+
+    override fun process(resolver: Resolver) {
+        val files = resolver.getAllFiles()
+
+        files.forEach {
+            it.accept(collector, references)
+        }
+
+        val sortedReferences = references.filter { it.element is KSClassifierReference && it.origin == Origin.KOTLIN }.sortedBy { (it.element as KSClassifierReference).referencedName() }
+
+        for (i in sortedReferences) {
+            val r = i.resolve()
+            results.add("${r?.declaration?.qualifiedName?.asString()}")
+        }
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+}

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -113,6 +113,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/referenceElement.kt");
     }
 
+    @TestMetadata("typeParameterReference.kt")
+    public void testTypeParameterReference() throws Exception {
+        runTest("plugins/ksp/testData/api/typeParameterReference.kt");
+    }
+
     @TestMetadata("varianceTypeCheck.kt")
     public void testVarianceTypeCheck() throws Exception {
         runTest("plugins/ksp/testData/api/varianceTypeCheck.kt");

--- a/plugins/ksp/testData/api/typeParameterReference.kt
+++ b/plugins/ksp/testData/api/typeParameterReference.kt
@@ -1,0 +1,17 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: TypeParameterReferenceProcessor
+// EXPECTED:
+// Foo.T1
+// Foo.bar.T2
+// foo.T3
+// END
+
+class Foo<T1> {
+    inner class Bar {
+        val v: T1
+    }
+
+    fun <T2> bar(p: T2) = 1
+}
+
+fun <T3> foo(p: T3) = 1


### PR DESCRIPTION
Performance should be on par with the original implementation for cases
that were covered, because `getResolutionScopeForDeclaration` resolves
the containing class descriptor if any.