### PR TITLE
fork findPsi() for filtering out synthetic members

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
@@ -13,11 +13,11 @@ import org.jetbrains.kotlin.container.get
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
-import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.ksp.processing.KSBuiltIns
 import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.*
+import org.jetbrains.kotlin.ksp.symbol.impl.findPsi
 import org.jetbrains.kotlin.ksp.symbol.impl.java.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.*
 import org.jetbrains.kotlin.load.java.components.TypeUsage

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ImplicitElementProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ImplicitElementProcessor.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.ksp.processor
 
 import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.KSPropertyDeclaration
 
 class ImplicitElementProcessor : AbstractTestProcessor() {
     val result: MutableList<String> = mutableListOf()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -11,10 +11,10 @@ import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
-import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.ksp.symbol.impl.findPsi
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSValueArgumentLiteImpl

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.ksp.symbol.impl
 import com.intellij.lang.jvm.JvmModifier
 import com.intellij.psi.*
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.ClassKind
@@ -23,7 +22,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
+import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.StarProjectionImpl
 import org.jetbrains.kotlin.types.TypeProjectionImpl
@@ -246,4 +245,10 @@ internal fun FunctionDescriptor.toKSFunctionDeclaration(): KSFunctionDeclaration
         is PsiMethod -> KSFunctionDeclarationJavaImpl.getCached(psi)
         else -> throw IllegalStateException("unexpected psi: ${psi.javaClass}")
     }
+}
+
+internal fun DeclarationDescriptor.findPsi(): PsiElement? {
+    // For synthetic members.
+    if ((this is CallableMemberDescriptor) && this.kind != CallableMemberDescriptor.Kind.DECLARATION) return null
+    return (this as? DeclarationDescriptorWithSource)?.source?.getPsi()
 }


### PR DESCRIPTION
since we now have multiple usages of findPsi() in our code it makes sense to do a fork. In particular, this fixes MemberDescriptor.toKSDeclaration() for synthetic primary constructor.