### PR TITLE
Support KSName path identifier based naming

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSName.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSName.kt
@@ -15,6 +15,12 @@ interface KSName {
     fun asString(): String
 
     /**
+     * Path/Identifier representation of the name.
+     */
+    fun asPathIdentifier(): String
+
+
+    /**
      * Qualifier of the name.
      */
     fun getQualifier(): String

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processing/impl/ResolverImpl.kt
@@ -135,7 +135,8 @@ class ResolverImpl(
     }
 
     override fun getSymbolsWithAnnotation(annotationName: String): List<KSAnnotated> {
-        val ksName = KSNameImpl.getCached(annotationName)
+        val annotationClass = getClassDeclarationByName(getKSNameFromString(annotationName))
+        val ksName = annotationClass?.qualifiedName ?: return emptyList()
 
         val visitor = object : BaseVisitor() {
             val symbols = mutableSetOf<KSAnnotated>()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/PathIdentifierProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/PathIdentifierProcessor.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.visitor.KSTopDownVisitor
+
+class PathIdentifierProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    override fun process(resolver: Resolver) {
+        val visitor = NameCollector()
+        resolver.getAllFiles().map { it.accept(visitor, result) }
+    }
+
+}
+
+class NameCollector : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+
+    override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {}
+
+    override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: MutableCollection<String>) {
+        classDeclaration.qualifiedName?.asPathIdentifier()?.let { data.add(if (it == "") "<no name>" else it) }
+        super.visitClassDeclaration(classDeclaration, data)
+    }
+
+    override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: MutableCollection<String>) {
+        function.qualifiedName?.asPathIdentifier()?.let { data.add(if (it == "") "<no name>" else it) }
+        super.visitFunctionDeclaration(function, data)
+    }
+
+    override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: MutableCollection<String>) {
+        property.qualifiedName?.asPathIdentifier()?.let { data.add(if (it == "") "<no name>" else it) }
+        super.visitPropertyDeclaration(property, data)
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.replaceTypeArguments
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.ksp.symbol.impl.toPathIdentifierName
 import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.getDescriptorsFiltered
@@ -74,7 +74,7 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
     }
 
     override val qualifiedName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
+        descriptor.toPathIdentifierName()
     }
 
     override val simpleName: KSName by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toFunctionKSModifiers
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toPathIdentifierName
 import org.jetbrains.kotlin.load.java.isFromJava
 import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
@@ -60,7 +61,7 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
     }
 
     override val qualifiedName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
+        descriptor.toPathIdentifierName()
     }
 
     override val simpleName: KSName by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -66,7 +66,7 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
     }
 
     override val qualifiedName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
+        descriptor.toPathIdentifierName()
     }
 
     override val setter: KSPropertySetter? by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSVariance
+import org.jetbrains.kotlin.ksp.symbol.impl.toPathIdentifierName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypeParameterDescriptor) : KSTypeParameter,
@@ -36,7 +37,7 @@ class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypePara
     }
 
     override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
+        descriptor.toPathIdentifierName()
     }
 
     override val typeParameters: List<KSTypeParameter> = emptyList()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -77,11 +77,7 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
     }
 
     override val qualifiedName: KSName by lazy {
-        if (ktClassOrObject.fqName == null) {
-            KSNameImpl.getCached("")
-        } else {
-            KSNameImpl.getCached(ktClassOrObject.fqName!!.asString())
-        }
+        ktClassOrObject.toPathIdentifierName()
     }
 
     override val simpleName: KSName by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -98,7 +98,7 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
     }
 
     override val qualifiedName: KSName? by lazy {
-        ktFunction.fqName?.asString()?.let { KSNameImpl.getCached(it) }
+        ktFunction.toPathIdentifierName()
     }
 
     override val returnType: KSTypeReference by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSNameImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSNameImpl.kt
@@ -14,14 +14,18 @@ class KSNameImpl private constructor(val name: String) : KSName {
     }
 
     override fun asString(): String {
+        return name.replace("/", ".")
+    }
+
+    override fun asPathIdentifier(): String {
         return name
     }
 
     override fun getQualifier(): String {
-        return name.split(".").dropLast(1).joinToString(".")
+        return name.substringBeforeLast('/')
     }
 
     override fun getShortName(): String {
-        return name.split(".").last()
+        return name.split("/").last()
     }
 }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -71,7 +71,7 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
     }
 
     override val qualifiedName: KSName? by lazy {
-        ktProperty.fqName?.asString()?.let { KSNameImpl.getCached(it) }
+        ktProperty.toPathIdentifierName()
     }
 
     override val simpleName: KSName by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -10,10 +10,7 @@ import org.jetbrains.kotlin.ksp.isOpen
 import org.jetbrains.kotlin.ksp.isVisibleFrom
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
-import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
-import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
-import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
-import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
+import org.jetbrains.kotlin.ksp.symbol.impl.*
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtStubbedPsiUtil
@@ -62,7 +59,7 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
     }
 
     override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached("${parentDeclaration.qualifiedName!!.asString()}.${simpleName.asString()}")
+        ktParameter.toPathIdentifierName()
     }
 
     override val simpleName: KSName by lazy {

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -93,6 +93,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/makeNullable.kt");
     }
 
+    @TestMetadata("nameForPathIdentifier.kt")
+    public void testNameForPathIdentifier() throws Exception {
+        runTest("plugins/ksp/testData/api/nameForPathIdentifier.kt");
+    }
+
     @TestMetadata("platformDeclaration.kt")
     public void testPlatformDeclaration() throws Exception {
         runTest("plugins/ksp/testData/api/platformDeclaration.kt");

--- a/plugins/ksp/testData/api/nameForPathIdentifier.kt
+++ b/plugins/ksp/testData/api/nameForPathIdentifier.kt
@@ -1,0 +1,35 @@
+// TEST PROCESSOR: PathIdentifierProcessor
+// EXPECTED:
+// test/pack/Outer
+// test/pack/Outer.Val
+// test/pack/Outer.Foo
+// test/pack/Outer.Inner
+// test/pack/Outer.Inner.innerVal
+// test/pack/Outer.Inner.innerFoo
+// <no name>
+// test/pack/Outer.Nested
+// test/pack/Outer.Nested.nestedVal
+// test/pack/Outer.Nested.nestedFoo
+// <no name>
+// END
+// a.kt
+package test.pack
+
+class Outer {
+    val Val
+
+    fun Foo() {}
+
+    inner class Inner {
+        val innerVal: Int
+        fun innerFoo() {
+            class InnerLocal
+        }
+    }
+    class Nested {
+        private val nestedVal: Int
+        fun nestedFoo() {
+            val a = 1
+        }
+    }
+}


### PR DESCRIPTION
It is not possible to obtain package information from a KSName itself, my attempt to solve this problem is to make the underlying string to be package aware and therefore need to make adjustment to current declaration qualified name computation to generate package aware names.

I have to change the implementation of `getSymbolsWithAnnotation` to work with new KSName implementation, there is some performance penalty, a hack to avoid that is to use the dot based name to compare annotation type by calling `asString()` function, not sure if that is sound.