### PR TITLE
move shared logic for KSDeclaration implementations for kotlin files and binary

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -26,16 +26,6 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
         fun getCached(descriptor: ClassDescriptor) = cache.getOrPut(descriptor) { KSClassDeclarationDescriptorImpl(descriptor) }
     }
 
-    override val origin by lazy {
-        if (this.parentDeclaration?.origin != Origin.CLASS) Origin.SYNTHETIC else Origin.CLASS
-    }
-
-    override val location: Location = NonExistLocation
-
-    override val annotations: List<KSAnnotation> by lazy {
-        descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
-    }
-
     override val classKind: ClassKind by lazy {
         when (descriptor.kind) {
             KtClassKind.INTERFACE, KtClassKind.ANNOTATION_CLASS -> ClassKind.INTERFACE
@@ -44,8 +34,6 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
             KtClassKind.ENUM_CLASS, KtClassKind.ENUM_ENTRY -> ClassKind.ENUM
         }
     }
-
-    override val containingFile: KSFile? = null
 
     override val isCompanionObject by lazy {
         descriptor.isCompanionObject
@@ -57,29 +45,8 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
             .map { KSFunctionDeclarationDescriptorImpl.getCached(it as FunctionDescriptor) }
     }
 
-    override val parentDeclaration: KSDeclaration? by lazy {
-        val containingDescriptor = descriptor.parents.first()
-        when (containingDescriptor) {
-            is ClassDescriptor -> KSClassDeclarationDescriptorImpl.getCached(
-                containingDescriptor
-            )
-            is FunctionDescriptor -> KSFunctionDeclarationDescriptorImpl.getCached(
-                containingDescriptor
-            )
-            else -> null
-        } as KSDeclaration?
-    }
-
     override val primaryConstructor: KSFunctionDeclaration? by lazy {
         descriptor.unsubstitutedPrimaryConstructor?.let { KSFunctionDeclarationDescriptorImpl.getCached(it) }
-    }
-
-    override val qualifiedName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
-    }
-
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.name.asString())
     }
 
     override val superTypes: List<KSTypeReference> by lazy {
@@ -91,11 +58,7 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
     }
 
     override val typeParameters: List<KSTypeParameter> by lazy {
-        descriptor.declaredTypeParameters.map {
-            KSTypeParameterDescriptorImpl.getCached(
-                it
-            )
-        }
+        descriptor.declaredTypeParameters.map { KSTypeParameterDescriptorImpl.getCached(it) }
     }
 
     override val declarations: List<KSDeclaration> by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
@@ -6,13 +6,46 @@
 package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.backend.common.serialization.findPackage
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
-import org.jetbrains.kotlin.ksp.symbol.KSDeclaration
-import org.jetbrains.kotlin.ksp.symbol.KSName
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 
 abstract class KSDeclarationDescriptorImpl(descriptor: DeclarationDescriptor) : KSDeclaration {
+
+    override val origin = Origin.CLASS
+
+    override val containingFile: KSFile? = null
+
+    override val location: Location = NonExistLocation
+
+    override val annotations: List<KSAnnotation> by lazy {
+        descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
+    }
+
+    override val parentDeclaration: KSDeclaration? by lazy {
+        val containingDescriptor = descriptor.parents.first()
+        when (containingDescriptor) {
+            is ClassDescriptor -> KSClassDeclarationDescriptorImpl.getCached(containingDescriptor)
+            is FunctionDescriptor -> KSFunctionDeclarationDescriptorImpl.getCached(containingDescriptor)
+            else -> null
+        } as KSDeclaration?
+    }
+
     override val packageName: KSName by lazy {
         KSNameImpl.getCached(descriptor.findPackage().fqName.asString())
     }
+
+    override val qualifiedName: KSName by lazy {
+        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
+    }
+
+    override val simpleName: KSName by lazy {
+        KSNameImpl.getCached(descriptor.name.asString())
+    }
+
+
 }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -28,25 +28,6 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
         fun getCached(descriptor: FunctionDescriptor) = cache.getOrPut(descriptor) { KSFunctionDeclarationDescriptorImpl(descriptor) }
     }
 
-    override val origin = Origin.CLASS
-
-    override val location: Location = NonExistLocation
-
-    override val containingFile: KSFile? = null
-
-    override val parentDeclaration: KSDeclaration? by lazy {
-        val containingDescriptor = descriptor.parents.first()
-        when (containingDescriptor) {
-            is ClassDescriptor -> KSClassDeclarationDescriptorImpl.getCached(
-                containingDescriptor
-            )
-            is FunctionDescriptor -> KSFunctionDeclarationDescriptorImpl.getCached(
-                containingDescriptor
-            )
-            else -> null
-        } as KSDeclaration?
-    }
-
     override fun overrides(overridee: KSFunctionDeclaration): Boolean {
         if (!overridee.isOpen())
             return false
@@ -58,20 +39,8 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
         ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
     }
 
-    override val qualifiedName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
-    }
-
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.name.asString())
-    }
-
     override val typeParameters: List<KSTypeParameter> by lazy {
         descriptor.typeParameters.map { KSTypeParameterDescriptorImpl.getCached(it) }
-    }
-
-    override val annotations: List<KSAnnotation> by lazy {
-        descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }
 
     override val declarations: List<KSDeclaration> = emptyList()

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -23,18 +23,6 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         fun getCached(descriptor: PropertyDescriptor) = cache.getOrPut(descriptor) { KSPropertyDeclarationDescriptorImpl(descriptor) }
     }
 
-    override val origin by lazy {
-        if (this.parentDeclaration?.origin != Origin.CLASS) Origin.SYNTHETIC else Origin.CLASS
-    }
-
-    override val location: Location = NonExistLocation
-
-    override val annotations: List<KSAnnotation> by lazy {
-        descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
-    }
-
-    override val containingFile: KSFile? = null
-
     override val extensionReceiver: KSTypeReference? by lazy {
         if (descriptor.extensionReceiverParameter != null) {
             KSTypeReferenceDescriptorImpl.getCached(descriptor.extensionReceiverParameter!!.type)
@@ -53,23 +41,6 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         }
     }
 
-    override val parentDeclaration: KSDeclaration? by lazy {
-        val containingDescriptor = descriptor.parents.first()
-        when (containingDescriptor) {
-            is ClassDescriptor -> KSClassDeclarationDescriptorImpl.getCached(
-                containingDescriptor
-            )
-            is FunctionDescriptor -> KSFunctionDeclarationDescriptorImpl.getCached(
-                containingDescriptor
-            )
-            else -> null
-        } as KSDeclaration?
-    }
-
-    override val qualifiedName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
-    }
-
     override val setter: KSPropertySetter? by lazy {
         if (descriptor.setter != null) {
             KSPropertySetterDescriptorImpl.getCached(descriptor.setter as PropertySetterDescriptor)
@@ -84,10 +55,6 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         } else {
             null
         }
-    }
-
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.name.asString())
     }
 
     override val typeParameters: List<KSTypeParameter> by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
@@ -23,21 +23,8 @@ class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypePara
         fun getCached(descriptor: TypeParameterDescriptor) = cache.getOrPut(descriptor) { KSTypeParameterDescriptorImpl(descriptor) }
     }
 
-    override val origin by lazy {
-        if (this.parentDeclaration?.origin != Origin.CLASS) Origin.SYNTHETIC else Origin.CLASS
-    }
-
-    override val location: Location = NonExistLocation
-
     override val bounds: List<KSTypeReference> by lazy {
         descriptor.upperBounds.map { KSTypeReferenceDescriptorImpl.getCached(it) }
-    }
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(descriptor.name.asString())
-    }
-
-    override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached(descriptor.fqNameSafe.asString())
     }
 
     override val typeParameters: List<KSTypeParameter> = emptyList()
@@ -51,8 +38,6 @@ class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypePara
         }
     }
 
-    override val containingFile: KSFile? = null
-
     override val modifiers: Set<Modifier> = emptySet()
 
     override val isReified: Boolean by lazy {
@@ -64,10 +49,6 @@ class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypePara
     }
 
     override val variance: Variance = descriptor.variance.toKSVariance()
-
-    override val annotations: List<KSAnnotation> by lazy {
-        descriptor.annotations.map{ KSAnnotationDescriptorImpl.getCached(it) }
-    }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitTypeParameter(this, data)

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -19,28 +19,15 @@ import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.getDescriptorsFiltered
 import org.jetbrains.kotlin.types.typeUtil.replaceArgumentsWithStarProjections
 
-class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrObject) : KSClassDeclaration, KSDeclarationImpl(),
+class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrObject) : KSClassDeclaration,
+    KSDeclarationImpl(ktClassOrObject),
     KSExpectActual by KSExpectActualImpl(ktClassOrObject) {
     companion object : KSObjectCache<KtClassOrObject, KSClassDeclarationImpl>() {
         fun getCached(ktClassOrObject: KtClassOrObject) = cache.getOrPut(ktClassOrObject) { KSClassDeclarationImpl(ktClassOrObject) }
     }
 
-    override val origin = Origin.KOTLIN
-
-    override val location: Location by lazy {
-        ktClassOrObject.toLocation()
-    }
-
-    override val annotations: List<KSAnnotation> by lazy {
-        ktClassOrObject.annotationEntries.map { KSAnnotationImpl.getCached(it) }
-    }
-
     override val classKind: ClassKind by lazy {
         ktClassOrObject.getClassType()
-    }
-
-    override val containingFile: KSFile by lazy {
-        KSFileImpl.getCached(ktClassOrObject.containingKtFile)
     }
 
     override val isCompanionObject by lazy {
@@ -62,46 +49,13 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
         result
     }
 
-    override val modifiers: Set<Modifier> by lazy {
-        ktClassOrObject.toKSModifiers()
-    }
-
-    override val parentDeclaration: KSDeclaration? by lazy {
-        ktClassOrObject.findParentDeclaration()
-    }
-
     override val primaryConstructor: KSFunctionDeclaration? by lazy {
         ktClassOrObject.primaryConstructor?.let { KSFunctionDeclarationImpl.getCached(it) }
             ?: if (classKind == ClassKind.CLASS || classKind == ClassKind.ENUM) KSConstructorSyntheticImpl.getCached(this) else null
     }
 
-    override val qualifiedName: KSName by lazy {
-        if (ktClassOrObject.fqName == null) {
-            KSNameImpl.getCached("")
-        } else {
-            KSNameImpl.getCached(ktClassOrObject.fqName!!.asString())
-        }
-    }
-
-    override val simpleName: KSName by lazy {
-        if (ktClassOrObject.name == null) {
-            KSNameImpl.getCached("")
-        } else {
-            KSNameImpl.getCached(ktClassOrObject.name!!)
-        }
-    }
-
     override val superTypes: List<KSTypeReference> by lazy {
         ktClassOrObject.superTypeListEntries.map { KSTypeReferenceImpl.getCached(it.typeReference!!) }
-    }
-
-    override val typeParameters: List<KSTypeParameter> by lazy {
-        ktClassOrObject.typeParameters.map {
-            KSTypeParameterImpl.getCached(
-                it,
-                ktClassOrObject
-            )
-        }
     }
 
     private val descriptor: ClassDescriptor by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -17,24 +17,10 @@ import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.calls.inference.returnTypeOrNothing
 import java.lang.IllegalStateException
 
-class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) : KSFunctionDeclaration, KSDeclarationImpl(),
+class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) : KSFunctionDeclaration, KSDeclarationImpl(ktFunction),
     KSExpectActual by KSExpectActualImpl(ktFunction) {
     companion object : KSObjectCache<KtFunction, KSFunctionDeclarationImpl>() {
         fun getCached(ktFunction: KtFunction) = cache.getOrPut(ktFunction) { KSFunctionDeclarationImpl(ktFunction) }
-    }
-
-    override val origin = Origin.KOTLIN
-
-    override val location: Location by lazy {
-        ktFunction.toLocation()
-    }
-
-    override val annotations: List<KSAnnotation> by lazy {
-        ktFunction.annotationEntries.map { KSAnnotationImpl.getCached(it) }
-    }
-
-    override val containingFile: KSFile by lazy {
-        KSFileImpl.getCached(ktFunction.containingKtFile)
     }
 
     override fun overrides(overridee: KSFunctionDeclaration): Boolean {
@@ -85,20 +71,8 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
                         && !this.ktFunction.hasBody())
     }
 
-    override val modifiers: Set<Modifier> by lazy {
-        ktFunction.toKSModifiers()
-    }
-
     override val parameters: List<KSVariableParameter> by lazy {
         ktFunction.valueParameters.map { KSVariableParameterImpl.getCached(it) }
-    }
-
-    override val parentDeclaration: KSDeclaration? by lazy {
-        ktFunction.findParentDeclaration()
-    }
-
-    override val qualifiedName: KSName? by lazy {
-        ktFunction.fqName?.asString()?.let { KSNameImpl.getCached(it) }
     }
 
     override val returnType: KSTypeReference by lazy {
@@ -110,14 +84,6 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
                 KSTypeImpl.getCached(desc.returnTypeOrNothing)
             }
         }
-    }
-
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(ktFunction.name!!)
-    }
-
-    override val typeParameters: List<KSTypeParameter> by lazy {
-        ktFunction.typeParameters.map { KSTypeParameterImpl.getCached(it, ktFunction) }
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -21,24 +21,10 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
-class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) : KSPropertyDeclaration, KSDeclarationImpl(),
+class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) : KSPropertyDeclaration, KSDeclarationImpl(ktProperty),
     KSExpectActual by KSExpectActualImpl(ktProperty) {
     companion object : KSObjectCache<KtProperty, KSPropertyDeclarationImpl>() {
         fun getCached(ktProperty: KtProperty) = cache.getOrPut(ktProperty) { KSPropertyDeclarationImpl(ktProperty) }
-    }
-
-    override val origin = Origin.KOTLIN
-
-    override val location: Location by lazy {
-        ktProperty.toLocation()
-    }
-
-    override val annotations: List<KSAnnotation> by lazy {
-        ktProperty.annotationEntries.map { KSAnnotationImpl.getCached(it) }
-    }
-
-    override val containingFile: KSFile by lazy {
-        KSFileImpl.getCached(ktProperty.containingKtFile)
     }
 
     override val extensionReceiver: KSTypeReference? by lazy {
@@ -73,26 +59,6 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
                 KSPropertySetterSyntheticImpl.getCached(this)
             }
         }
-    }
-
-    override val modifiers: Set<Modifier> by lazy {
-        ktProperty.toKSModifiers()
-    }
-
-    override val parentDeclaration: KSDeclaration? by lazy {
-        ktProperty.findParentDeclaration()
-    }
-
-    override val qualifiedName: KSName? by lazy {
-        ktProperty.fqName?.asString()?.let { KSNameImpl.getCached(it) }
-    }
-
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(ktProperty.name!!)
-    }
-
-    override val typeParameters: List<KSTypeParameter> by lazy {
-        ktProperty.typeParameters.map { KSTypeParameterImpl.getCached(it, ktProperty) }
     }
 
     override val type: KSTypeReference? by lazy {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -23,18 +23,12 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtStubbedPsiUtil
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
-class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: KtParameter) : KSPropertyDeclaration, KSDeclarationImpl(),
+class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: KtParameter) : KSPropertyDeclaration,
+    KSDeclarationImpl(ktParameter),
     KSExpectActual by KSExpectActualImpl(ktParameter) {
     companion object : KSObjectCache<KtParameter, KSPropertyDeclarationParameterImpl>() {
         fun getCached(ktParameter: KtParameter) = cache.getOrPut(ktParameter) { KSPropertyDeclarationParameterImpl(ktParameter) }
     }
-
-    override val origin = Origin.KOTLIN
-
-    override val location: Location by lazy {
-        ktParameter.toLocation()
-    }
-
     override val extensionReceiver: KSTypeReference? = null
 
     override val getter: KSPropertyGetter? by lazy {
@@ -57,36 +51,6 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
         }
     }
 
-    override val annotations: List<KSAnnotation> by lazy {
-        ktParameter.annotationEntries.map { KSAnnotationImpl.getCached(it) }
-    }
-
-    override val containingFile: KSFile? by lazy {
-        KSFileImpl.getCached(ktParameter.containingKtFile)
-    }
-
-    override val modifiers: Set<Modifier> by lazy {
-        ktParameter.toKSModifiers()
-    }
-
-    override val parentDeclaration: KSDeclaration by lazy {
-        KtStubbedPsiUtil.getContainingDeclaration(ktParameter)!!.findParentDeclaration()!!
-    }
-
-    override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached("${parentDeclaration.qualifiedName!!.asString()}.${simpleName.asString()}")
-    }
-
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(ktParameter.name ?: "_")
-    }
-
-    override val typeParameters: List<KSTypeParameter> by lazy {
-        ktParameter.typeParameters.map {
-            KSTypeParameterImpl.getCached(it, KtStubbedPsiUtil.getContainingDeclaration(ktParameter, KtClassOrObject::class.java)!!)
-        }
-    }
-
     override fun isDelegated(): Boolean = false
 
     override fun overrides(overridee: KSPropertyDeclaration): Boolean {
@@ -101,7 +65,7 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
         val superDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(overridee) ?: return false
         val subDescriptor = ResolverImpl.instance.resolveDeclaration(ktParameter) as PropertyDescriptor
         return OverridingUtil.DEFAULT.isOverridableBy(
-                superDescriptor, subDescriptor, null
+            superDescriptor, subDescriptor, null
         ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
     }
 

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
@@ -12,57 +12,18 @@ import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.*
 
-class KSTypeAliasImpl private constructor(val ktTypeAlias: KtTypeAlias) : KSTypeAlias, KSDeclarationImpl(),
+class KSTypeAliasImpl private constructor(val ktTypeAlias: KtTypeAlias) : KSTypeAlias, KSDeclarationImpl(ktTypeAlias),
     KSExpectActual by KSExpectActualImpl(ktTypeAlias) {
     companion object : KSObjectCache<KtTypeAlias, KSTypeAliasImpl>() {
         fun getCached(ktTypeAlias: KtTypeAlias) = cache.getOrPut(ktTypeAlias) { KSTypeAliasImpl(ktTypeAlias) }
-    }
-
-    override val origin = Origin.KOTLIN
-
-    override val location: Location by lazy {
-        ktTypeAlias.toLocation()
-    }
-
-    override val containingFile: KSFile by lazy {
-        KSFileImpl.getCached(ktTypeAlias.containingKtFile)
     }
 
     override val name: KSName by lazy {
         KSNameImpl.getCached(ktTypeAlias.name!!)
     }
 
-    override val parentDeclaration: KSDeclaration? by lazy {
-        ktTypeAlias.findParentDeclaration()
-    }
-
-    override val qualifiedName: KSName by lazy {
-        KSNameImpl.getCached(ktTypeAlias.fqName!!.asString())
-    }
-
-    override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(ktTypeAlias.name!!)
-    }
-
     override val type: KSTypeReference by lazy {
         KSTypeReferenceImpl.getCached(ktTypeAlias.getTypeReference()!!)
-    }
-
-    override val typeParameters: List<KSTypeParameter> by lazy {
-        ktTypeAlias.typeParameters.map {
-            KSTypeParameterImpl.getCached(
-                it,
-                ktTypeAlias
-            )
-        }
-    }
-
-    override val annotations: List<KSAnnotation> by lazy {
-        ktTypeAlias.annotationEntries.map { KSAnnotationImpl.getCached(it) }
-    }
-
-    override val modifiers: Set<Modifier> by lazy {
-        ktTypeAlias.toKSModifiers()
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
@@ -13,24 +13,16 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
-class KSTypeParameterImpl private constructor(val ktTypeParameter: KtTypeParameter, val owner: KtTypeParameterListOwner) : KSTypeParameter, KSDeclarationImpl(),
+class KSTypeParameterImpl private constructor(val ktTypeParameter: KtTypeParameter, val owner: KtTypeParameterListOwner) : KSTypeParameter,
+    KSDeclarationImpl(ktTypeParameter),
     KSExpectActual by KSExpectActualNoImpl() {
     companion object : KSObjectCache<Pair<KtTypeParameter, KtTypeParameterListOwner>, KSTypeParameterImpl>() {
-        fun getCached(ktTypeParameter: KtTypeParameter, owner: KtTypeParameterListOwner) = cache.getOrPut(Pair(ktTypeParameter, owner)) { KSTypeParameterImpl(ktTypeParameter, owner) }
-    }
-
-    override val origin = Origin.KOTLIN
-
-    override val location: Location by lazy {
-        ktTypeParameter.toLocation()
+        fun getCached(ktTypeParameter: KtTypeParameter, owner: KtTypeParameterListOwner) =
+            cache.getOrPut(Pair(ktTypeParameter, owner)) { KSTypeParameterImpl(ktTypeParameter, owner) }
     }
 
     override val name: KSName by lazy {
         KSNameImpl.getCached(ktTypeParameter.name!!)
-    }
-
-    override val annotations: List<KSAnnotation> by lazy {
-        ktTypeParameter.annotationEntries.map { KSAnnotationImpl.getCached(it) }
     }
 
     override val isReified: Boolean by lazy {
@@ -59,9 +51,6 @@ class KSTypeParameterImpl private constructor(val ktTypeParameter: KtTypeParamet
         KSNameImpl.getCached(ktTypeParameter.name ?: "_")
     }
 
-    override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached(ktTypeParameter.containingClassOrObject?.fqName?.asString() ?: "" + "." + simpleName.asString())
-    }
     override val typeParameters: List<KSTypeParameter> = emptyList()
 
     override val parentDeclaration: KSDeclaration? by lazy {
@@ -71,14 +60,6 @@ class KSTypeParameterImpl private constructor(val ktTypeParameter: KtTypeParamet
             is KtProperty -> KSPropertyDeclarationImpl.getCached(owner)
             else -> throw IllegalStateException()
         }
-    }
-
-    override val containingFile: KSFile? by lazy {
-        KSFileImpl.getCached(ktTypeParameter.containingKtFile)
-    }
-
-    override val modifiers: Set<Modifier> by lazy {
-        ktTypeParameter.toKSModifiers()
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {


### PR DESCRIPTION
For Java impls, due to the class hierarchy in Psi, it is not easy to find a representative class for abstraction in KSDeclarationJavaImpl