### PR TITLE
support annotation use-site target

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/AnnotationUseSiteTarget.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/AnnotationUseSiteTarget.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.symbol
+
+enum class AnnotationUseSiteTarget {
+    FILE,
+    PROPERTY,
+    FIELD,
+    GET,
+    SET,
+    RECEIVER,
+    PARAM,
+    SETPARAM,
+    DELEGATE
+}

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSAnnotation.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSAnnotation.kt
@@ -25,4 +25,9 @@ interface KSAnnotation : KSNode {
      * Short name for this annotation, equivalent to the simple name of the declaration of the annotation class.
      */
     val shortName: KSName
+
+    /**
+     * Use site target of the annotation. Could be null if no annotation use site target is specified.
+     */
+    val useSiteTarget: AnnotationUseSiteTarget?
 }

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
@@ -149,6 +149,14 @@ fun KSDeclaration.closestClassDeclaration(): KSClassDeclaration? {
     }
 }
 
+fun KSAnnotated.findAnnotationFromUseSiteTarget(): Collection<KSAnnotation> {
+    return when (this) {
+        is KSPropertyGetter -> this.receiver.annotations.filter { it.useSiteTarget == AnnotationUseSiteTarget.GET }
+        is KSPropertySetter -> this.receiver.annotations.filter { it.useSiteTarget == AnnotationUseSiteTarget.SET }
+        else -> emptyList()
+    }
+}
+
 
 // TODO: cross module visibility is not handled
 fun KSDeclaration.isVisibleFrom(other: KSDeclaration): Boolean {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ImplicitElementProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ImplicitElementProcessor.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.ksp.processor
 
+import org.jetbrains.kotlin.ksp.findAnnotationFromUseSiteTarget
 import org.jetbrains.kotlin.ksp.processing.Resolver
 import org.jetbrains.kotlin.ksp.symbol.KSDeclaration
 import org.jetbrains.kotlin.ksp.symbol.KSPropertyDeclaration
@@ -25,13 +26,13 @@ class ImplicitElementProcessor : AbstractTestProcessor() {
         result.add(ITF.primaryConstructor?.simpleName?.asString() ?: "<null>")
         result.add(resolver.getClassDeclarationByName(resolver.getKSNameFromString("JavaClass"))!!.primaryConstructor?.simpleName?.asString() ?: "<null>")
         val readOnly = ClsClass.declarations.single { it.simpleName.asString() == "readOnly" } as KSPropertyDeclaration
-        readOnly.getter?.let { result.add("readOnly.get(): ${it.origin}") }
+        readOnly.getter?.let { result.add("readOnly.get(): ${it.origin} annotations from property: ${it.findAnnotationFromUseSiteTarget().map { it.shortName.asString() }.joinToString(",")}") }
         readOnly.getter?.receiver?.let { result.add("readOnly.getter.owner: " + nameAndOrigin(it)) }
         readOnly.setter?.let { result.add("readOnly.set(): ${it.origin}") }
         readOnly.setter?.receiver?.let { result.add("readOnly.setter.owner: " + nameAndOrigin(it)) }
         val readWrite = ClsClass.declarations.single { it.simpleName.asString() == "readWrite" } as KSPropertyDeclaration
         readWrite.getter?.let { result.add("readWrite.get(): ${it.origin}") }
-        readWrite.setter?.let { result.add("readWrite.set(): ${it.origin}") }
+        readWrite.setter?.let { result.add("readWrite.set(): ${it.origin} annotations from property: ${it.findAnnotationFromUseSiteTarget().map { it.shortName.asString() }.joinToString(",")}") }
         val dataClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("Data"))!!
         val comp1 = dataClass.declarations.single { it.simpleName.asString() == "comp1" } as KSPropertyDeclaration
         comp1.getter?.let { result.add("comp1.get(): ${it.origin}") }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -44,6 +44,8 @@ class KSAnnotationDescriptorImpl private constructor(val descriptor: AnnotationD
         KSNameImpl.getCached(descriptor.fqName!!.shortName().asString())
     }
 
+    override val useSiteTarget: AnnotationUseSiteTarget? = null
+
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitAnnotation(this, data)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -60,6 +60,8 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
         KSNameImpl.getCached(psi.qualifiedName!!.split(".").last())
     }
 
+    override val useSiteTarget: AnnotationUseSiteTarget? = null
+
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitAnnotation(this, data)
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -36,6 +36,21 @@ class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEn
         KSNameImpl.getCached(ktAnnotationEntry.shortName!!.asString())
     }
 
+    override val useSiteTarget: AnnotationUseSiteTarget? by lazy {
+        when (ktAnnotationEntry.useSiteTarget?.getAnnotationUseSiteTarget()) {
+            null -> null
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.FILE -> AnnotationUseSiteTarget.FILE
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY -> AnnotationUseSiteTarget.PROPERTY
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.FIELD -> AnnotationUseSiteTarget.FIELD
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_GETTER -> AnnotationUseSiteTarget.GET
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_SETTER -> AnnotationUseSiteTarget.SET
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.RECEIVER -> AnnotationUseSiteTarget.RECEIVER
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
+            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
+        }
+    }
+
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitAnnotation(this, data)
     }

--- a/plugins/ksp/testData/api/implicitElements.kt
+++ b/plugins/ksp/testData/api/implicitElements.kt
@@ -3,17 +3,23 @@
 // <init>; origin: SYNTHETIC
 // <null>
 // <null>
-// readOnly.get(): SYNTHETIC
+// readOnly.get(): SYNTHETIC annotations from property: GetAnno
 // readOnly.getter.owner: readOnly: KOTLIN
 // readWrite.get(): KOTLIN
-// readWrite.set(): SYNTHETIC
+// readWrite.set(): SYNTHETIC annotations from property: SetAnno
 // comp1.get(): SYNTHETIC
 // comp2.get(): SYNTHETIC
 // comp2.set(): SYNTHETIC
 // END
 // FILE: a.kt
+annotation class GetAnno
+annotation class SetAnno
+
 class Cls {
+    @get:GetAnno
     val readOnly: Int = 1
+
+    @set:SetAnno
     var readWrite: Int = 2
     get() = 1
 }


### PR DESCRIPTION
Currently only use-site target on accessors has meaningful counterpart in KSP, other targets like `RECEIVER` requires the receiver to be modeled as parameter which is not how KSP models receivers.