### PR TITLE
Force resolve descriptors before looking up.

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/FunctionTypeAliasProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/FunctionTypeAliasProcessor.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSTypeImpl
+import org.jetbrains.kotlin.ksp.visitor.KSTopDownVisitor
+import org.jetbrains.kotlin.types.getAbbreviation
+
+open class FunctionTypeAliasProcessor: AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    val typeRefCollector = RefCollector()
+    val refs = mutableSetOf<KSTypeReference>()
+
+    override fun process(resolver: Resolver) {
+        val files = resolver.getAllFiles()
+
+        files.forEach {
+            it.accept(typeRefCollector, refs)
+        }
+
+        val types = refs.mapNotNull { it.resolve() }.sortedBy { it.toString() }.distinctBy { it.toString() }
+
+        for (i in types) {
+            for (j in types) {
+                results.add("$i ?= $j : ${i.isAssignableFrom(j)} / ${i == j}")
+            }
+        }
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+}
+
+open class RefCollector : KSTopDownVisitor<MutableCollection<KSTypeReference>, Unit>() {
+    override fun defaultHandler(node: KSNode, data: MutableCollection<KSTypeReference>) = Unit
+
+    override fun visitTypeReference(typeReference: KSTypeReference, data: MutableCollection<KSTypeReference>) {
+        super.visitTypeReference(typeReference, data)
+        data.add(typeReference)
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeAliasComparisonProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/TypeAliasComparisonProcessor.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.*
+import org.jetbrains.kotlin.ksp.visitor.KSTopDownVisitor
+
+open class TypeAliasComparisonProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    val typeRefCollector = TypeRefCollector()
+    val refs = mutableSetOf<KSTypeReference>()
+
+    override fun process(resolver: Resolver) {
+        val files = resolver.getAllFiles()
+
+        files.forEach {
+            it.accept(typeRefCollector, refs)
+        }
+
+        fun KSType.aliases(): List<KSType> =
+            listOf(this) + ((this.declaration as? KSTypeAlias)?.type?.resolve()?.aliases() ?: emptyList())
+
+        val interesting = setOf("Anno", "Bnno")
+        val iRefs = refs.filterNot { it.annotations.all { it.shortName.asString() !in interesting } }
+        val types = iRefs.map { it.resolve()!! }.flatMap { it.aliases() }
+
+        for (i in types) {
+            for (j in types) {
+                results.add("$i = $j : ${i.isAssignableFrom(j)}")
+            }
+        }
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+}
+
+open class TypeRefCollector : KSTopDownVisitor<MutableCollection<KSTypeReference>, Unit>() {
+    override fun defaultHandler(node: KSNode, data: MutableCollection<KSTypeReference>) = Unit
+
+    override fun visitTypeReference(typeReference: KSTypeReference, data: MutableCollection<KSTypeReference>) {
+        super.visitTypeReference(typeReference, data)
+        data.add(typeReference)
+    }
+}

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -73,6 +73,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/errorTypes.kt");
     }
 
+    @TestMetadata("functionTypeAlias.kt")
+    public void testFunctionTypeAlias() throws Exception {
+        runTest("plugins/ksp/testData/api/functionTypeAlias.kt");
+    }
+
     @TestMetadata("hello.kt")
     public void testHello() throws Exception {
         runTest("plugins/ksp/testData/api/hello.kt");

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -128,6 +128,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/typeAlias.kt");
     }
 
+    @TestMetadata("typeAliasComparison.kt")
+    public void testTypeAliasComparison() throws Exception {
+        runTest("plugins/ksp/testData/api/typeAliasComparison.kt");
+    }
+
     @TestMetadata("typeComposure.kt")
     public void testTypeComposure() throws Exception {
         runTest("plugins/ksp/testData/api/typeComposure.kt");

--- a/plugins/ksp/testData/api/functionTypeAlias.kt
+++ b/plugins/ksp/testData/api/functionTypeAlias.kt
@@ -1,0 +1,24 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: FunctionTypeAliasProcessor
+// EXPECTED:
+// Function1<String, String> ?= Function1<String, String> : true / true
+// Function1<String, String> ?= String : false / false
+// Function1<String, String> ?= [typealias F] : false / false
+// Function1<String, String> ?= [typealias Foo] : true / true
+// String ?= Function1<String, String> : false / false
+// String ?= String : true / true
+// String ?= [typealias F] : true / true
+// String ?= [typealias Foo] : false / false
+// [typealias F] ?= Function1<String, String> : false / false
+// [typealias F] ?= String : true / true
+// [typealias F] ?= [typealias F] : true / true
+// [typealias F] ?= [typealias Foo] : false / false
+// [typealias Foo] ?= Function1<String, String> : true / true
+// [typealias Foo] ?= String : false / false
+// [typealias Foo] ?= [typealias F] : false / false
+// [typealias Foo] ?= [typealias Foo] : true / true
+// END
+
+typealias F = String
+val y: Foo = { it }
+typealias Foo = (F) -> String

--- a/plugins/ksp/testData/api/typeAliasComparison.kt
+++ b/plugins/ksp/testData/api/typeAliasComparison.kt
@@ -1,0 +1,29 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: TypeAliasComparisonProcessor
+// EXPECTED:
+// [@Anno] [typealias F] = [@Anno] [typealias F] : true
+// [@Anno] [typealias F] = String : true
+// [@Anno] [typealias F] = [@Bnno] [typealias F] : true
+// [@Anno] [typealias F] = String : true
+// String = [@Anno] [typealias F] : true
+// String = String : true
+// String = [@Bnno] [typealias F] : true
+// String = String : true
+// [@Bnno] [typealias F] = [@Anno] [typealias F] : true
+// [@Bnno] [typealias F] = String : true
+// [@Bnno] [typealias F] = [@Bnno] [typealias F] : true
+// [@Bnno] [typealias F] = String : true
+// String = [@Anno] [typealias F] : true
+// String = String : true
+// String = [@Bnno] [typealias F] : true
+// String = String : true
+// END
+
+annotation class Anno
+annotation class Bnno
+
+typealias F = String
+typealias Foo = (@Anno F) -> String
+
+fun bar(arg: @Bnno F) {
+}


### PR DESCRIPTION
Aliases are unfortunately not expanded while they are resolved in some
descriptors. Therefore we need to expand them explicitly.

The accidental fall-through to typeResolver.resolveType(file_scope) is
also explicitly disabled / fixed.
