### PR TITLE
Move isLocal to KSDeclaration interface, add findOverridee() function…

### DIFF
--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSFunctionDeclaration.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSFunctionDeclaration.kt
@@ -45,4 +45,11 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
      * Calling [overrides] is expensive and should be avoided if possible.
      */
     fun overrides(overridee: KSFunctionDeclaration): Boolean
+
+    /**
+     * Find the original overridee of this function, if overriding.
+     * @return [KSFunctionDeclaration] for the original function, if overriding, otherwise null.
+     * Calling [findOverridee] is expensive and should be avoided if possible.
+     */
+    fun findOverridee(): KSFunctionDeclaration?
 }

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSPropertyDeclaration.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/symbol/KSPropertyDeclaration.kt
@@ -51,4 +51,11 @@ interface KSPropertyDeclaration : KSDeclaration {
      * Calling [overrides] is expensive and should be avoided if possible.
      */
     fun overrides(overridee: KSPropertyDeclaration): Boolean
+
+    /**
+     * Find the original overridee of this property, if overriding.
+     * @return [KSPropertyDeclaration] for the original property, if overriding, otherwise null.
+     * Calling [findOverridee] is expensive and should be avoided if possible.
+     */
+    fun findOverridee(): KSPropertyDeclaration?
 }

--- a/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
+++ b/libraries/tools/kotlin-symbol-processing-api/src/org/jetbrains/kotlin/ksp/utils.kt
@@ -74,6 +74,13 @@ fun KSTypeAlias.findActualType(): KSClassDeclaration {
  */
 fun KSDeclaration.getVisibility(): Visibility {
     return when {
+        this.modifiers.contains(Modifier.OVERRIDE) -> {
+            when (this) {
+                is KSFunctionDeclaration -> this.findOverridee()?.getVisibility()
+                is KSPropertyDeclaration -> this.findOverridee()?.getVisibility()
+                else -> null
+            } ?: Visibility.PUBLIC
+        }
         this.isLocal() -> Visibility.LOCAL
         this.modifiers.contains(Modifier.PRIVATE) -> Visibility.PRIVATE
         this.modifiers.contains(Modifier.PROTECTED) || this.modifiers.contains(Modifier.OVERRIDE) -> Visibility.PROTECTED
@@ -124,7 +131,8 @@ fun KSPropertyDeclaration.isAbstract() = this.modifiers.contains(Modifier.ABSTRA
         || ((this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE && this.getter == null && this.setter == null)
 
 fun KSDeclaration.isOpen() = !this.isLocal()
-        && (this.modifiers.contains(Modifier.OVERRIDE)
+        && ((this as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE
+        || this.modifiers.contains(Modifier.OVERRIDE)
         || this.modifiers.contains(Modifier.ABSTRACT)
         || this.modifiers.contains(Modifier.OPEN)
         || (this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DeclarationUtilProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/DeclarationUtilProcessor.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.ksp.processor
+
+import org.jetbrains.kotlin.ksp.*
+import org.jetbrains.kotlin.ksp.processing.Resolver
+import org.jetbrains.kotlin.ksp.symbol.KSDeclaration
+import org.jetbrains.kotlin.ksp.symbol.KSNode
+import org.jetbrains.kotlin.ksp.visitor.KSTopDownVisitor
+
+class DeclarationUtilProcessor : AbstractTestProcessor() {
+    private val result = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    override fun process(resolver: Resolver) {
+        val visitor = DeclarationCollector()
+        resolver.getAllFiles().map { it.accept(visitor, result) }
+    }
+}
+
+class DeclarationCollector : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+    override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
+    }
+
+    override fun visitDeclaration(declaration: KSDeclaration, data: MutableCollection<String>) {
+        data.add("${declaration.qualifiedName?.asString() ?: "<simple name: ${declaration.simpleName.asString()}>"}: ${declaration.isInternal()}: ${declaration.isLocal()}: ${declaration.isPrivate()}: ${declaration.isProtected()}: ${declaration.isPublic()}: ${declaration.isOpen()}")
+    }
+}

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.impl.AnonymousFunctionDescriptor
 import org.jetbrains.kotlin.ksp.isOpen
@@ -13,19 +12,22 @@ import org.jetbrains.kotlin.ksp.isVisibleFrom
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
-import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.toFunctionKSModifiers
+import org.jetbrains.kotlin.ksp.symbol.impl.toKSFunctionDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.load.java.isFromJava
 import org.jetbrains.kotlin.resolve.OverridingUtil
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 
 class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: FunctionDescriptor) : KSFunctionDeclaration,
     KSDeclarationDescriptorImpl(descriptor),
     KSExpectActual by KSExpectActualDescriptorImpl(descriptor) {
     companion object : KSObjectCache<FunctionDescriptor, KSFunctionDeclarationDescriptorImpl>() {
         fun getCached(descriptor: FunctionDescriptor) = cache.getOrPut(descriptor) { KSFunctionDeclarationDescriptorImpl(descriptor) }
+    }
+
+    override fun findOverridee(): KSFunctionDeclaration? {
+        return ResolverImpl.instance.resolveFunctionDeclaration(this)?.original?.overriddenDescriptors?.singleOrNull { it.overriddenDescriptors.isEmpty() }
+            ?.toKSFunctionDeclaration()
     }
 
     override fun overrides(overridee: KSFunctionDeclaration): Boolean {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -82,6 +82,11 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
     }
 
+    override fun findOverridee(): KSPropertyDeclaration? {
+        return ResolverImpl.instance.resolvePropertyDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
+            ?.toKSPropertyDeclaration()
+    }
+
     override fun isDelegated(): Boolean {
         return (descriptor as? PropertyDescriptor)?.delegateField != null
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -13,12 +13,9 @@ import org.jetbrains.kotlin.ksp.isOpen
 import org.jetbrains.kotlin.ksp.isVisibleFrom
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
-import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
-import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
+import org.jetbrains.kotlin.ksp.symbol.impl.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
-import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
-import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.resolve.OverridingUtil
 
 class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KSFunctionDeclaration, KSDeclarationJavaImpl(),
@@ -39,6 +36,11 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KS
 
     override val containingFile: KSFile? by lazy {
         KSFileJavaImpl.getCached(psi.containingFile as PsiJavaFile)
+    }
+
+    override fun findOverridee(): KSFunctionDeclaration? {
+        return ResolverImpl.instance.resolveFunctionDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
+            ?.toKSFunctionDeclaration()
     }
 
     override fun overrides(overridee: KSFunctionDeclaration): Boolean {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -7,13 +7,11 @@ package org.jetbrains.kotlin.ksp.symbol.impl.java
 
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiJavaFile
+import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
-import org.jetbrains.kotlin.ksp.symbol.impl.KSObjectCache
-import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
+import org.jetbrains.kotlin.ksp.symbol.impl.*
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.kotlin.KSNameImpl
-import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
-import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
 
 class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSPropertyDeclaration, KSDeclarationJavaImpl(),
     KSExpectActual by KSExpectActualNoImpl() {
@@ -67,6 +65,10 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSP
 
     override fun overrides(overridee: KSPropertyDeclaration): Boolean {
         return false
+    }
+
+    override fun findOverridee(): KSPropertyDeclaration? {
+        return null
     }
 
     override fun isDelegated(): Boolean {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
@@ -9,9 +9,7 @@ import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.findParentDeclaration
 import org.jetbrains.kotlin.ksp.symbol.impl.toKSModifiers
 import org.jetbrains.kotlin.ksp.symbol.impl.toLocation
-import org.jetbrains.kotlin.psi.KtDeclaration
-import org.jetbrains.kotlin.psi.KtNamedDeclaration
-import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
+import org.jetbrains.kotlin.psi.*
 
 abstract class KSDeclarationImpl(ktDeclaration: KtDeclaration) : KSDeclaration {
     override val origin: Origin = Origin.KOTLIN

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -23,6 +23,11 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
         fun getCached(ktFunction: KtFunction) = cache.getOrPut(ktFunction) { KSFunctionDeclarationImpl(ktFunction) }
     }
 
+    override fun findOverridee(): KSFunctionDeclaration? {
+        return ResolverImpl.instance.resolveFunctionDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
+            ?.toKSFunctionDeclaration()
+    }
+
     override fun overrides(overridee: KSFunctionDeclaration): Boolean {
         if (!this.modifiers.contains(Modifier.OVERRIDE))
             return false

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -14,8 +14,6 @@ import org.jetbrains.kotlin.ksp.isVisibleFrom
 import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.impl.*
-import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSPropertyGetterDescriptorImpl
-import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSPropertySetterDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.synthetic.KSPropertyGetterSyntheticImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.synthetic.KSPropertySetterSyntheticImpl
 import org.jetbrains.kotlin.psi.KtProperty
@@ -107,6 +105,11 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
         return OverridingUtil.DEFAULT.isOverridableBy(
                 superDescriptor, subDescriptor, null
         ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
+    }
+
+    override fun findOverridee(): KSPropertyDeclaration? {
+        return ResolverImpl.instance.resolvePropertyDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
+            ?.toKSPropertyDeclaration()
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
@@ -61,6 +61,8 @@ class KSConstructorSyntheticImpl(val ksClassDeclaration: KSClassDeclaration) : K
 
     override fun overrides(overridee: KSFunctionDeclaration): Boolean = false
 
+    override fun findOverridee(): KSFunctionDeclaration? = null
+
     override fun findActuals(): List<KSDeclaration> {
         return emptyList()
     }

--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/symbol/impl/utils.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.ksp.processing.impl.ResolverImpl
 import org.jetbrains.kotlin.ksp.symbol.*
 import org.jetbrains.kotlin.ksp.symbol.ClassKind
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSFunctionDeclarationDescriptorImpl
+import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSPropertyDeclarationDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.java.KSClassDeclarationJavaImpl
 import org.jetbrains.kotlin.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
@@ -243,6 +244,17 @@ internal fun FunctionDescriptor.toKSFunctionDeclaration(): KSFunctionDeclaration
     return when (psi) {
         is KtFunction -> KSFunctionDeclarationImpl.getCached(psi)
         is PsiMethod -> KSFunctionDeclarationJavaImpl.getCached(psi)
+        else -> throw IllegalStateException("unexpected psi: ${psi.javaClass}")
+    }
+}
+
+internal fun PropertyDescriptor.toKSPropertyDeclaration(): KSPropertyDeclaration {
+    if (this.kind != CallableMemberDescriptor.Kind.DECLARATION) return KSPropertyDeclarationDescriptorImpl.getCached(this)
+    val psi = this.findPsi() ?: return KSPropertyDeclarationDescriptorImpl.getCached(this)
+    return when (psi) {
+        is KtProperty -> KSPropertyDeclarationImpl.getCached(psi)
+        is KtParameter -> KSPropertyDeclarationParameterImpl.getCached(psi)
+        // This function should not be invoked against a Java symbol based descriptor.
         else -> throw IllegalStateException("unexpected psi: ${psi.javaClass}")
     }
 }

--- a/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
+++ b/plugins/ksp/test/org/jetbrains/kotlin/ksp/test/KotlinKSPTestGenerated.java
@@ -68,6 +68,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("plugins/ksp/testData/api/declarationPackageName.kt");
     }
 
+    @TestMetadata("declarationUtil.kt")
+    public void testDeclarationUtil() throws Exception {
+        runTest("plugins/ksp/testData/api/declarationUtil.kt");
+    }
+
     @TestMetadata("errorTypes.kt")
     public void testErrorTypes() throws Exception {
         runTest("plugins/ksp/testData/api/errorTypes.kt");

--- a/plugins/ksp/testData/api/declarationUtil.kt
+++ b/plugins/ksp/testData/api/declarationUtil.kt
@@ -1,0 +1,50 @@
+// TEST PROCESSOR: DeclarationUtilProcessor
+// FORMAT: <name>: isInternal: isLocal: isPrivate: isProtected: isPublic: isOpen
+// EXPECTED:
+// Cls: true: false: false: false: false: false
+// <simple name: Cls>: false: false: false: false: true: false
+// <simple name: aaa>: false: true: false: false: false: false
+// Cls.prop: false: false: false: false: true: true
+// Cls.protectedProp: false: false: false: true: false: true
+// Cls.abstractITFFun: false: false: false: false: true: true
+// Cls.pri: false: false: true: false: false: false
+// Cls.b: false: false: false: false: true: true
+// ITF: false: false: false: false: true: true
+// ITF.prop: false: false: false: false: true: true
+// ITF.protectedProp: false: false: false: true: false: true
+// ITF.b: false: false: false: false: true: true
+// ITF.abstractITFFun: false: false: false: false: true: true
+// ITF.nonAbstractITFFun: false: false: false: false: true: true
+// <simple name: aa>: false: true: false: false: false: false
+// END
+// FILE: a.kt
+internal class Cls(override val b: Int) : ITF {
+    constructor() {
+        val aaa = 2
+        Cls(aaa)
+    }
+    override val prop: Int = 2
+
+    override val protectedProp: Int = 2
+
+    override fun abstractITFFun(): Int {
+        return 2
+    }
+
+    private val pri: Int = 3
+}
+
+interface ITF {
+    val prop: Int
+
+    protected val protectedProp: Int
+
+    val b: Int = 1
+
+    fun abstractITFFun(): Int
+
+    fun nonAbstractITFFun(): Int {
+        val aa = "local"
+        return 1
+    }
+}


### PR DESCRIPTION
… for KSFunctionDeclaration and KSPropertyDeclaration. Fix util function for isOpen() and getVisibility().

* KSDeclaration.isLocal() util is changed to be part of the interface to return correctly for val/var members in primary constructor.
* add findOverridee() function to return the original overridden function/property for an overrider.
* Fix KSDeclaration.isOpen() util for KSDeclaration to return interface as open class.
* Fix KSDeclaration.getVisibility util to return correct visibility for overriders, overrider should carry same visbility as there overridee.