### PR TITLE
workaround for type resolution bug

### DIFF
--- a/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ImplicitElementProcessor.kt
+++ b/plugins/ksp/src/org/jetbrains/kotlin/ksp/processor/ImplicitElementProcessor.kt
@@ -40,5 +40,7 @@ class ImplicitElementProcessor : AbstractTestProcessor() {
         val comp2 = dataClass.declarations.single { it.simpleName.asString() == "comp2" } as KSPropertyDeclaration
         comp2.getter?.let { result.add("comp2.get(): ${it.origin}") }
         comp2.setter?.let { result.add("comp2.set(): ${it.origin}") }
+        val annotationType = comp1.annotations[0].annotationType.resolve()!!.declaration.qualifiedName!!.asString()
+        result.add(annotationType)
     }
 }

--- a/plugins/ksp/testData/api/implicitElements.kt
+++ b/plugins/ksp/testData/api/implicitElements.kt
@@ -10,6 +10,7 @@
 // comp1.get(): SYNTHETIC
 // comp2.get(): SYNTHETIC
 // comp2.set(): SYNTHETIC
+// GetAnno
 // END
 // FILE: a.kt
 annotation class GetAnno
@@ -24,7 +25,7 @@ class Cls {
     get() = 1
 }
 
-data class Data(val comp1: Int, var comp2: Int)
+data class Data(@get:GetAnno val comp1: Int, var comp2: Int)
 
 interface ITF
 


### PR DESCRIPTION
~Looks really semantically identical to me, I am just replacing the way of lambdas being invoked, basically just restoring the original lambda usage, and no type resolution logic is affected. Honestly have no idea why it was broken and fixed this way.~

Issue is with resolved results not written into binding context, not sure why in debug mode when I manually evaluate the `resolveDeclaration` call it can help with writing results into binding context.